### PR TITLE
removed obsolete BuildRequires

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.changes
+++ b/package/yast2-pkg-bindings-devel-doc.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 14 08:29:51 UTC 2013 - lslezak@suse.cz
+
+- removed obsolete BuildRequires (blocxx, libgcrypt, doxygen,
+  perl-XML-Writer)
+
+-------------------------------------------------------------------
 Mon Jan 28 10:42:12 UTC 2013 - lslezak@suse.cz
 
 - fixed documentation build (bnc#800692)

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 14 08:29:51 UTC 2013 - lslezak@suse.cz
+
+- removed obsolete BuildRequires (blocxx, libgcrypt, doxygen,
+  perl-XML-Writer)
+
+-------------------------------------------------------------------
 Wed May 22 13:00:04 UTC 2013 - lslezak@suse.cz
 
 - removed logging from finishParameters() function

--- a/yast2-pkg-bindings-devel-doc.spec.in
+++ b/yast2-pkg-bindings-devel-doc.spec.in
@@ -11,8 +11,13 @@ Source0:        yast2-pkg-bindings-@VERSION@.tar.bz2
 Prefix:         %_prefix
 
 # same as in the main package (because we use the same configure.in.in)
-BuildRequires:	blocxx-devel docbook-xsl-stylesheets doxygen libgcrypt-devel libxslt perl-XML-Writer sgml-skel yast2-core-devel yast2-devtools libzypp-devel 
-BuildRequires:  libtool gcc-c++
+BuildRequires:  docbook-xsl-stylesheets
+BuildRequires:  gcc-c++
+BuildRequires:  libtool
+BuildRequires:  libxslt
+BuildRequires:  libzypp-devel >= 6.10.0
+BuildRequires:  yast2-core-devel
+BuildRequires:  yast2-devtools
 
 Buildarch: noarch
 Requires:  yast2-pkg-bindings = %{version}

--- a/yast2-pkg-bindings.spec.in
+++ b/yast2-pkg-bindings.spec.in
@@ -3,12 +3,17 @@
 @HEADER@
 Group:	System/YaST
 License: GPL-2.0
-BuildRequires: blocxx-devel docbook-xsl-stylesheets doxygen libgcrypt-devel libxslt perl-XML-Writer sgml-skel yast2-core-devel yast2-devtools
-BuildRequires: libzypp-devel >= 6.10.0
-BuildRequires: libtool gcc-c++
+
+BuildRequires:  docbook-xsl-stylesheets
+BuildRequires:  gcc-c++
+BuildRequires:  libtool
+BuildRequires:  libxslt
+BuildRequires:  libzypp-devel >= 6.10.0
+BuildRequires:  yast2-core-devel
+BuildRequires:  yast2-devtools
 
 # new GPG callbacks
-Requires:	libzypp >= 6.6.0
+Requires:	libzypp >= 6.10.0
 
 Summary:	YaST2 - Package Manager Access
 


### PR DESCRIPTION
blocxx, libgcrypt, doxygen, perl-XML-Writer
