### PR TITLE
Fixed double /var/tmp/ download prefix (bnc#847794)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.2
+Version:        3.1.3
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 10 09:02:41 UTC 2014 - lslezak@suse.cz
+
+- zypp::filesystem::TmpDir::defaultLocation() already contains
+  /var/tmp/ prefix, do not use it it twice (bnc#847794)
+- 3.1.3
+
+-------------------------------------------------------------------
 Wed Dec 18 08:27:46 UTC 2013 - lslezak@suse.cz
 
 - eliminate deprecated zypp::DiskUsage class (bnc#852943)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.2
+Version:        3.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -131,6 +131,9 @@ class PkgFunctions
       // set new target directory
       bool SetTarget(const std::string &root);
 
+      // configured or default download area
+      zypp::Pathname download_area_path();
+
       // helper - is the network running?
       bool NetworkDetected();
 

--- a/src/Source_Download.cc
+++ b/src/Source_Download.cc
@@ -98,8 +98,8 @@ YCPValue PkgFunctions::SourceProvideFileCommon(const YCPInteger &id,
 		zypp::OnMediaLocation mloc(media_path, mid->value());
 		mloc.setOptional(optional);
 
-		// create the tmpdir in <_download_area>/var/tmp
-		zypp::filesystem::TmpDir tmpdir(_download_area / zypp::filesystem::TmpDir::defaultLocation());
+		// create the tmpdir in <_download_area>
+		zypp::filesystem::TmpDir tmpdir(download_area_path());
 
 		// keep a reference to the tmpdir so the directory is not deleted at the and of the block		
 		tmp_dirs.push_back(tmpdir);
@@ -344,10 +344,10 @@ PkgFunctions::SourceProvideDirectoryInternal(const YCPInteger& id, const YCPInte
 		zypp::Fetcher f;
 		f.reset();
 		zypp::OnMediaLocation mloc(d->value(), mid->value());
-		// create the tmpdir in <_root>/var/tmp
-		zypp::filesystem::TmpDir tmpdir(_download_area / zypp::filesystem::TmpDir::defaultLocation() );
+		// create the tmpdir in <_download_area>
+		zypp::filesystem::TmpDir tmpdir(download_area_path());
 
-		// keep the reference to the tmpdir so the directory is not deleted at the and of the block		
+		// keep the reference to the tmpdir so the directory is not deleted at the and of the block
 		tmp_dirs.push_back(tmpdir);
 		path = tmpdir.path();
 		f.setOptions(zypp::Fetcher::AutoAddIndexes);
@@ -466,4 +466,10 @@ PkgFunctions::SourceForceRefreshNow (const YCPInteger& id)
 {
     // force refresh
     return SourceRefreshHelper(id, true);
+}
+
+zypp::Pathname PkgFunctions::download_area_path()
+{
+    // create the tmpdir in the default location if _download_area is empty
+    return _download_area.empty() ? zypp::filesystem::TmpDir::defaultLocation() : _download_area;
 }


### PR DESCRIPTION
- **zypp::filesystem::TmpDir::defaultLocation()** already contains
  `/var/tmp/` prefix, do not use it twice ([bnc#847794](https://bugzilla.novell.com/show_bug.cgi?id=847794))
- 3.1.3
