### PR TITLE
fixed saving service to installed system (bnc#877053)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May  9 15:21:18 UTC 2014 - lslezak@suse.cz
+
+- fixed saving service to installed system (bnc#877053)
+- 3.1.10
+
+-------------------------------------------------------------------
 Tue Apr 22 12:40:55 UTC 2014 - lslezak@suse.cz
 
 - remeber the base product NVRA (instead of the zypp product

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -297,10 +297,10 @@ void ServiceManager::SavePkgService(PkgService &s_known, zypp::RepoManager &repo
 
     std::string orig_alias(s_known.origAlias());
 
-    y2internal("orig_alias: %s", orig_alias.c_str());
+    y2debug("orig_alias: %s", orig_alias.c_str());
 
-    // the old alias is empty for new services
-    if (orig_alias.empty())
+    // already saved?
+    if (s_stored == zypp::ServiceInfo::noService)
     {
         y2milestone("Adding new service %s", alias.c_str());
         // add the service


### PR DESCRIPTION
- 3.1.10

After changing the target to `/mnt` the original alias is not empty anymore (the services have been already saved into inst-sys when adding registration repositories), rather ask the repository manager whether the repository already exists or not.

(Tested in the latest build using DUD and it works.)
