### PR TITLE
Move package cache to /mnt (bnc#877859)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue May 27 13:18:29 UTC 2014 - lslezak@suse.cz
+
+- move package cache to target system (copy RPMs to /mnt instead of
+  inst-sys (RAM-disk) during installation to avoid freezing the
+  installer when installing big packages with small RAM)
+  (bnc#877859)
+- 3.1.12
+
+-------------------------------------------------------------------
 Tue May 20 06:22:19 UTC 2014 - jreidinger@suse.com
 
 - another fix for repeated service save problem (bnc#876134)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -459,6 +459,26 @@ bool PkgFunctions::RepoManagerUpdateTarget(const std::string& root)
         repo_manager = new_repo_manager;
     }
 
+    // update package cache path for loaded repositories when changing the target
+    if (new_target)
+    {
+        zypp::RepoManagerOptions repo_options(root);
+        zypp::Pathname packages_prefix = repo_options.repoPackagesCachePath;
+
+        zypp::ResPool pool = zypp_ptr()->pool();
+        for_(it, pool.knownRepositoriesBegin(), pool.knownRepositoriesEnd())
+        {
+            zypp::RepoInfo repo = it->info();
+            repo.setPackagesPath(packages_prefix / repo.escaped_alias());
+
+            y2milestone("Setting package cache for repository %s: %s",
+                repo.alias().c_str(),
+                repo.packagesPath().asString().c_str());
+
+            it->setInfo(repo);
+        }
+    }
+
     return new_target;
 }
 


### PR DESCRIPTION
to avoid freezing the installer when installing big packages with small RAM
- 3.1.12
