### PR TITLE
added Pkg::TargetInitializeOptions() (bnc#881320)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.13
+Version:        3.1.14
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  5 18:37:51 UTC 2014 - lslezak@suse.cz
+
+- added Pkg::TargetInitializeOptions(), allows overriding the
+  target distribution autodetection (bnc#881320)
+- 3.1.14
+
+-------------------------------------------------------------------
 Wed Jun  4 07:15:20 UTC 2014 - lslezak@suse.cz
 
 - do not log false warning message about missing base product

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.13
+Version:        3.1.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -31,10 +31,11 @@
 #include <string>
 #include <vector>
 
+#include <ycp/YCPMap.h>
+
 class YCPBoolean;
 class YCPValue;
 class YCPList;
-class YCPMap;
 class YCPSymbol;
 class YCPString;
 class YCPInteger;
@@ -127,10 +128,10 @@ class PkgFunctions
 
       // helper for updating repository manager after changing the target root
       // return true if the target root has been changed
-      bool RepoManagerUpdateTarget(const std::string& root);
+      bool RepoManagerUpdateTarget(const std::string& root, const YCPMap& options = YCPMap());
 
       // set new target directory
-      bool SetTarget(const std::string &root);
+      bool SetTarget(const std::string &root, const YCPMap& options = YCPMap());
 
       // configured or default download area
       zypp::Pathname download_area_path();
@@ -555,6 +556,8 @@ class PkgFunctions
 	YCPValue TargetRebuildInit(const YCPString& root);
         /* TYPEINFO: boolean(string)*/
         YCPValue TargetInitialize (const YCPString& root);
+        /* TYPEINFO: boolean(string, map<any,any>)*/
+        YCPValue TargetInitializeOptions (const YCPString& root, const YCPMap& options);
         /* TYPEINFO: boolean()*/
         YCPValue TargetLoad ();
 	/* TYPEINFO: boolean()*/

--- a/src/Target_Load.cc
+++ b/src/Target_Load.cc
@@ -91,7 +91,7 @@ PkgFunctions::TargetInitInternal(const YCPString& root, bool rebuild_rpmdb)
 	y2error("TargetInit has failed: %s", excpt.msg().c_str() );
         return YCPError(excpt.msg().c_str(), YCPBoolean(false));
     }
-    
+
     // locks are optional, might not be present on the target
     zypp::Pathname lock_file(_target_root + zypp::ZConfig::instance().locksFile());
     try
@@ -106,7 +106,7 @@ PkgFunctions::TargetInitInternal(const YCPString& root, bool rebuild_rpmdb)
     }
 
     pkgprogress.Done();
-    
+
     return YCPBoolean(true);
 }
 
@@ -147,12 +147,29 @@ PkgFunctions::TargetRebuildInit(const YCPString& root)
 YCPValue
 PkgFunctions::TargetInitialize (const YCPString& root)
 {
+  return TargetInitializeOptions(root, YCPMap());
+}
+
+/** ------------------------
+ *
+ * @builtin TargetInitializeOptions
+ * @short Initialize Target, read the keys, set the repomanager options
+ * @param string root Root Directory
+ * @param map options for RepoManager
+ *   supproted keys:
+ *   "target_distro": <string> - override the target distribution autodetection,
+ *     example values: "sle-11-x86_84", "sle-12-x86_84"
+ * @return boolean
+ */
+YCPValue
+PkgFunctions::TargetInitializeOptions (const YCPString& root, const YCPMap& options)
+{
     const std::string r = root->value();
 
     try
     {
         zypp_ptr()->initializeTarget(r);
-        SetTarget(r);
+        SetTarget(r, options);
     }
     catch (zypp::Exception & excpt)
     {
@@ -160,7 +177,7 @@ PkgFunctions::TargetInitialize (const YCPString& root)
         y2error("TargetInit has failed: %s", excpt.msg().c_str() );
         return YCPError(excpt.msg().c_str(), YCPBoolean(false));
     }
-    
+
     return YCPBoolean(true);
 }
 
@@ -199,7 +216,7 @@ PkgFunctions::TargetLoad ()
     }
 
     pkgprogress.Done();
-    
+
     return YCPBoolean(true);
 }
 
@@ -216,7 +233,7 @@ PkgFunctions::TargetFinish ()
     try
     {
 	zypp_ptr()->finishTarget();
-    
+
 	zypp::Pathname lock_file(_target_root + zypp::ZConfig::instance().locksFile());
 	zypp::Locks::instance().save(lock_file);
     }


### PR DESCRIPTION
allows overriding the target distribution autodetection
- 3.1.14
