### PR TITLE
Fixed ServiceRefresh to not add duplicated repositories (bnc#865037)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.14
+Version:        3.1.15
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jun 10 09:40:33 UTC 2014 - lslezak@suse.cz
+
+- fixed ServiceRefresh to not add duplicated repositories (that
+  confuses package installation progress during installation)
+  (bnc#865037)
+- 3.1.15
+
+-------------------------------------------------------------------
 Thu Jun  5 18:37:51 UTC 2014 - lslezak@suse.cz
 
 - added Pkg::TargetInitializeOptions(), allows overriding the

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.14
+Version:        3.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Service.cc
+++ b/src/Service.cc
@@ -414,7 +414,8 @@ YCPValue PkgFunctions::ServiceRefresh(const YCPString &alias)
             it != reps.end(); ++it)
         {
           y2debug("Checking repo '%s' from service '%s'", it->alias().c_str(), it->service().c_str());
-          if (it->service() == alias_str && !logFindAlias(it->alias()))
+          // skip repositories from other services or already loaded repositories
+          if (it->service() != alias_str || logFindAlias(it->alias()) > 0)
             continue;
 
           y2milestone("Service added a new repository: %s", it->alias().c_str());
@@ -423,7 +424,7 @@ YCPValue PkgFunctions::ServiceRefresh(const YCPString &alias)
 
           if (it->enabled())
           {
-            y2milestone("Refreshing service: %s", it->alias().c_str());
+            y2milestone("Refreshing repository: %s", it->alias().c_str());
             // refresh the last added repository
             SourceRefreshNow(repos.size() - 1);
 


### PR DESCRIPTION
that confuses package installation progress during installation
- 3.1.15
