### PR TITLE
Fixed passing an invalid repository ID in GPG key import callback

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.15
+Version:        3.1.16
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 19 06:58:42 UTC 2014 - lslezak@suse.cz
+
+- fixed passing an invalid repository ID in GPG key import callback
+  (bnc#891389)
+- 3.1.16
+
+-------------------------------------------------------------------
 Tue Jun 10 09:40:33 UTC 2014 - lslezak@suse.cz
 
 - fixed ServiceRefresh to not add duplicated repositories (that

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.15
+Version:        3.1.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -1649,7 +1649,7 @@ namespace ZyppRecipients {
 		GPGMap gpgmap(key);
 
 		callback.addMap(gpgmap.getMap());
-		long long srcid = _pkg_ref.logFindAlias(context.repoInfo().alias());
+		PkgFunctions::RepoId srcid = context.empty() ? _pkg_ref.current_repo_id() : _pkg_ref.logFindAlias(context.repoInfo().alias());
 		callback.addInt(srcid);
 
 		bool res = callback.evaluateBool();

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -63,6 +63,7 @@ PkgFunctions::PkgFunctions () :
     , zypp_pointer(NULL)
     , repo_manager(NULL)
     , autorefresh_skipped(false)
+    , current_repo(-1LL)
     , commit_policy(NULL)
     ,_callbackHandler( *new CallbackHandler(*this) )
     , base_product(NULL)

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -110,6 +110,8 @@ class PkgFunctions
 	// ID type
 	typedef long long RepoId;
 
+        RepoId current_repo_id() const { return current_repo; }
+
     private: // source related
     
       // all known installation sources
@@ -120,6 +122,9 @@ class PkgFunctions
     
       // flag for skipping autorefresh
       volatile bool autorefresh_skipped;
+
+      // flag
+      RepoId current_repo;
 
       RepoId last_reported_repo;
       int last_reported_mediumnr;

--- a/src/Source_Download.cc
+++ b/src/Source_Download.cc
@@ -76,6 +76,9 @@ YCPValue PkgFunctions::SourceProvideFileCommon(const YCPInteger &id,
 	mid->value()
     );
 
+    // remember the current repo (needed at GPG key import)
+    current_repo = id->value();
+
     zypp::filesystem::Pathname path; // FIXME use ManagedMedia
     if (found)
     {
@@ -135,6 +138,8 @@ YCPValue PkgFunctions::SourceProvideFileCommon(const YCPInteger &id,
 	    }
 	}
     }
+
+    current_repo = -1LL;
 
     // set the original probing value
     _silent_probing = _silent_probing_old;


### PR DESCRIPTION
See [bnc#891389](https://bugzilla.novell.com/show_bug.cgi?id=891389)
- 3.1.16
