### PR TITLE
explicitly include <ostream> (bnc#891676)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.16
+Version:        3.1.17
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 19 07:39:01 UTC 2014 - lslezak@suse.cz
+
+- explicitly include <ostream> to avoid possible compile failures
+  (bnc#891676)
+- 3.1.17
+
+-------------------------------------------------------------------
 Tue Aug 19 06:58:42 UTC 2014 - lslezak@suse.cz
 
 - fixed passing an invalid repository ID in GPG key import callback

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.16
+Version:        3.1.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Locks.cc
+++ b/src/Locks.cc
@@ -26,6 +26,8 @@
 */
 
 
+#include <ostream>
+
 #include "PkgFunctions.h"
 #include "log.h"
 

--- a/src/Resolvable_Patches.cc
+++ b/src/Resolvable_Patches.cc
@@ -25,6 +25,8 @@
    Namespace:   Pkg
 */
 
+#include <ostream>
+
 #include "PkgFunctions.h"
 #include "log.h"
 #include <y2util/Y2SLog.h>

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -18,6 +18,7 @@
  * ------------------------------------------------------------------------------
  */
 
+#include <ostream>
 
 #include "log.h"
 #include "ServiceManager.h"


### PR DESCRIPTION
to avoid possible compile failures

See [bnc#891676](https://bugzilla.novell.com/show_bug.cgi?id=891676) for details.
- 3.1.17
