### PR TITLE
Do not reorder baseurls by storing them in a std::set (SLE12 as well!)

### DIFF
--- a/src/Source_Set.cc
+++ b/src/Source_Set.cc
@@ -241,15 +241,14 @@ PkgFunctions::SourceChangeUrl (const YCPInteger& id, const YCPString& u)
         if (repo->repoInfo().baseUrlsSize() > 1)
         {
             // store current urls
-            std::set<zypp::Url> baseUrls (repo->repoInfo().baseUrlsBegin(), repo->repoInfo().baseUrlsEnd());
-            
+	    const zypp::RepoInfo::url_set & baseUrls(( repo->repoInfo().baseUrls() ));
+
             // reset url list and store the new one there
             repo->repoInfo().setBaseUrl(zypp::Url(u->value()));
 
             // add the rest of base urls
-            for (std::set<zypp::Url>::const_iterator i = baseUrls.begin();
-                    i != baseUrls.end(); ++i)
-                repo->repoInfo().addBaseUrl(*i);
+            for ( const auto & url : baseUrls )
+                repo->repoInfo().addBaseUrl(url);
         }
         else
             repo->repoInfo().setBaseUrl(zypp::Url(u->value()));


### PR DESCRIPTION
As we are going to support multiple baseurls in a repo file, and the order of appearance in the .repo file expresses a preference. Re-odering the urls by storing them in a `std::set` is not appropriate. Just follow `zypp::RepoInfo::url_set` (will change from `set` to `list`).

Please cherry-pick this for **SLE12 as well**. No need to do it for older distros.
