### PR TITLE
Callbacks: Remove legacy *PatchDownload callbacks

### DIFF
--- a/src/Callbacks.YCP.cc
+++ b/src/Callbacks.YCP.cc
@@ -102,12 +102,8 @@
 	ENUM_OUT( StartDeltaApply );
 	ENUM_OUT( ProgressDeltaApply );
 	ENUM_OUT( ProblemDeltaApply );
-	ENUM_OUT( StartPatchDownload );
-	ENUM_OUT( ProgressPatchDownload );
-	ENUM_OUT( ProblemPatchDownload );
 	ENUM_OUT( FinishDeltaDownload );
 	ENUM_OUT( FinishDeltaApply );
-	ENUM_OUT( FinishPatchDownload );
 	ENUM_OUT( MediaChange );
 	ENUM_OUT( SourceChange );
 	ENUM_OUT( ResolvableReport );

--- a/src/Callbacks.YCP.h
+++ b/src/Callbacks.YCP.h
@@ -78,8 +78,7 @@ class PkgFunctions::CallbackHandler::YCPCallbacks
       CB_StartSourceRefresh, CB_ErrorSourceRefresh, CB_DoneSourceRefresh, CB_ProgressSourceRefresh,
       CB_StartDeltaDownload, CB_ProgressDeltaDownload, CB_ProblemDeltaDownload,
       CB_StartDeltaApply, CB_ProgressDeltaApply, CB_ProblemDeltaApply,
-      CB_StartPatchDownload, CB_ProgressPatchDownload, CB_ProblemPatchDownload,
-      CB_FinishDeltaDownload, CB_FinishDeltaApply, CB_FinishPatchDownload,
+      CB_FinishDeltaDownload, CB_FinishDeltaApply,
       CB_StartDownload, CB_ProgressDownload, CB_DoneDownload, CB_InitDownload, CB_DestDownload,
 
       CB_SourceProbeStart, CB_SourceProbeFailed, CB_SourceProbeSucceeded, CB_SourceProbeEnd, CB_SourceProbeProgress, CB_SourceProbeError, 

--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -704,64 +704,6 @@ namespace ZyppRecipients {
 		callback.evaluate();
 	    }
 	}
-
-
-	// Download patch rpm:
-	// - path below url reported on start()
-	// - expected download size (0 if unknown)
-	// - download is interruptable
-	virtual void startPatchDownload( const zypp::Pathname & filename, const zypp::ByteCount & downloadsize )
-	{
-	    // reset the counter
-	    last_reported_patch_download = 0;
-	    last_reported_patch_download_time = time(NULL);
-
-	    CB callback( ycpcb( YCPCallbacks::CB_StartPatchDownload ) );
-	    if (callback._set) {
-		callback.addStr( filename.asString() );
-		callback.addInt( downloadsize );
-
-		callback.evaluate();
-	    }
-	}
-
-	virtual bool progressPatchDownload( int value )
-	{
-	    CB callback( ycpcb( YCPCallbacks::CB_ProgressPatchDownload) );
-	    time_t current_time = time(NULL);
-	    if (callback._set && (value - last_reported_patch_download >= 5 || last_reported_patch_download - value >= 5 || value == 100 || current_time - last_reported_patch_download_time >= callback_timeout))
-	    {
-		last_reported_patch_download = value;
-		last_reported_patch_download_time = current_time;
-		callback.addInt( value );
-
-		return callback.evaluateBool();
-	    }
-
-	    return zypp::repo::DownloadResolvableReport::progressPatchDownload(value);
-	}
-
-	virtual void problemPatchDownload( const std::string &description )
-	{
-	    CB callback( ycpcb( YCPCallbacks::CB_ProblemPatchDownload ) );
-
-	    if (callback._set) {
-		callback.addStr( description );
-
-		callback.evaluate();
-	    }
-	}
-
-	virtual void finishPatchDownload()
-	{
-	    CB callback( ycpcb( YCPCallbacks::CB_FinishPatchDownload ) );
-
-	    if (callback._set)
-	    {
-		callback.evaluate();
-	    }
-	}
-
     };
 
     ///////////////////////////////////////////////////////////////////

--- a/src/Callbacks_Register.cc
+++ b/src/Callbacks_Register.cc
@@ -303,32 +303,32 @@ YCPValue PkgFunctions::CallbackProblemDeltaApply( const YCPValue& args ) {
 
 /**
  * @builtin CallbackStartPatchDownload
- * @short Register callback function
+ * @short Register callback function (legacy, not used anymore)
  * @param string args Name of the callback handler function. Required callback prototype is <code>void(string filename, integer download_size)</code>. If the download size is unknown download_size is 0. The callback function is evaluated when a patch download has been started.
  * @return void
  */
 YCPValue PkgFunctions::CallbackStartPatchDownload( const YCPValue& args ) {
-  return SET_YCP_CB( CB_StartPatchDownload, args);
+  return YCPVoid();
 }
 
 /**
  * @builtin CallbackProgressPatchDownload
- * @short Register callback function
+ * @short Register callback function (legacy, not used anymore)
  * @param string args Name of the callback handler function. Required callback prototype is <code>boolean(integer value)</code>. The callback function is evaluated when more than 5% of the patch size has been downloaded since the last evaluation. If the handler returns false the download is aborted.
  * @return void
  */
 YCPValue PkgFunctions::CallbackProgressPatchDownload( const YCPValue& args ) {
-  return SET_YCP_CB( CB_ProgressPatchDownload, args);
+  return YCPVoid();
 }
 
 /**
  * @builtin CallbackProblemPatchDownload
- * @short Register callback function
+ * @short Register callback function (legacy, not used anymore)
  * @param string args Name of the callback handler function. Required callback prototype is <code>void(string description)</code>. The callback function should inform user that a problem has occurred during download of the patch.
  * @return void
  */
 YCPValue PkgFunctions::CallbackProblemPatchDownload( const YCPValue& args ) {
-  return SET_YCP_CB( CB_ProblemPatchDownload, args);
+  return YCPVoid();
 }
 
 
@@ -356,13 +356,13 @@ YCPValue PkgFunctions::CallbackFinishDeltaApply( const YCPValue& args)
 
 /**
  * @builtin CallbackFinishPatchDownload
- * @short Register callback function
+ * @short Register callback function (legacy, not used anymore)
  * @param string args Name of the callback handler function. Required callback prototype is <code>void()</code>. The callback function is evaluated when the patch download has been finished.
  * @return void
  */
 YCPValue PkgFunctions::CallbackFinishPatchDownload( const YCPValue& args)
 {
-    return SET_YCP_CB( CB_FinishPatchDownload, args);
+    return YCPVoid();
 }
 
 


### PR DESCRIPTION
zypp::repo::DownloadResolvableReport wants to remove the legacy
*PatchDownload callbacks. They are unused since 2008. The patch
removes the callbacks, keeping only the 4 Callback*PatchDownload
register functions which may be still used by yast. If not, they
could be removed as well.