### PR TITLE
Removed obsolete patch callbacks

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.21
+Version:        3.1.22
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  4 15:33:21 UTC 2015 - lslezak@suse.cz
+
+- removed obsolete patch callbacks
+- 3.1.22
+
+-------------------------------------------------------------------
 Fri Feb  6 11:12:30 UTC 2015 - lslezak@suse.cz
 
 - Pkg::RepositoryAdd: use alias from URL query parameter if present

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.21
+Version:        3.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Callbacks_Register.cc
+++ b/src/Callbacks_Register.cc
@@ -302,37 +302,6 @@ YCPValue PkgFunctions::CallbackProblemDeltaApply( const YCPValue& args ) {
 }
 
 /**
- * @builtin CallbackStartPatchDownload
- * @short Register callback function (legacy, not used anymore)
- * @param string args Name of the callback handler function. Required callback prototype is <code>void(string filename, integer download_size)</code>. If the download size is unknown download_size is 0. The callback function is evaluated when a patch download has been started.
- * @return void
- */
-YCPValue PkgFunctions::CallbackStartPatchDownload( const YCPValue& args ) {
-  return YCPVoid();
-}
-
-/**
- * @builtin CallbackProgressPatchDownload
- * @short Register callback function (legacy, not used anymore)
- * @param string args Name of the callback handler function. Required callback prototype is <code>boolean(integer value)</code>. The callback function is evaluated when more than 5% of the patch size has been downloaded since the last evaluation. If the handler returns false the download is aborted.
- * @return void
- */
-YCPValue PkgFunctions::CallbackProgressPatchDownload( const YCPValue& args ) {
-  return YCPVoid();
-}
-
-/**
- * @builtin CallbackProblemPatchDownload
- * @short Register callback function (legacy, not used anymore)
- * @param string args Name of the callback handler function. Required callback prototype is <code>void(string description)</code>. The callback function should inform user that a problem has occurred during download of the patch.
- * @return void
- */
-YCPValue PkgFunctions::CallbackProblemPatchDownload( const YCPValue& args ) {
-  return YCPVoid();
-}
-
-
-/**
  * @builtin CallbackFinishDeltaDownload
  * @short Register callback function
  * @param string args Name of the callback handler function. Required callback prototype is <code>void()</code>. The callback function is evaluated when the delta download has been finished.
@@ -353,18 +322,6 @@ YCPValue PkgFunctions::CallbackFinishDeltaApply( const YCPValue& args)
 {
     return SET_YCP_CB( CB_FinishDeltaApply, args);
 }
-
-/**
- * @builtin CallbackFinishPatchDownload
- * @short Register callback function (legacy, not used anymore)
- * @param string args Name of the callback handler function. Required callback prototype is <code>void()</code>. The callback function is evaluated when the patch download has been finished.
- * @return void
- */
-YCPValue PkgFunctions::CallbackFinishPatchDownload( const YCPValue& args)
-{
-    return YCPVoid();
-}
-
 
 /**
  * @builtin CallbackSourceCreateStart

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -320,18 +320,10 @@ class PkgFunctions
 	YCPValue CallbackProgressDeltaApply( const YCPValue& /*nil*/ args);
 	/* TYPEINFO: void(void(string)) */
 	YCPValue CallbackProblemDeltaApply( const YCPValue& /*nil*/ args);
-	/* TYPEINFO: void(void(string,integer)) */
-	YCPValue CallbackStartPatchDownload( const YCPValue& /*nil*/ args);
 	/* TYPEINFO: void(boolean(integer)) */
-	YCPValue CallbackProgressPatchDownload( const YCPValue& /*nil*/ args);
-	/* TYPEINFO: void(void(string)) */
-	YCPValue CallbackProblemPatchDownload( const YCPValue& /*nil*/ args);
-	/* TYPEINFO: void(void()) */
 	YCPValue CallbackFinishDeltaDownload( const YCPValue& /*nil*/ args);
 	/* TYPEINFO: void(void()) */
 	YCPValue CallbackFinishDeltaApply( const YCPValue& /*nil*/ args);
-	/* TYPEINFO: void(void()) */
-	YCPValue CallbackFinishPatchDownload( const YCPValue& /*nil*/ args);
 
 	/* TYPEINFO: void(void(string,string)) */
 	YCPValue CallbackStartDownload (const YCPValue& /*nil*/ args);


### PR DESCRIPTION
They have been removed from Yast and can be removed here as well.

- 3.1.22