### PR TITLE
Fixed saving removed services

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.24
+Version:        3.1.25
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 19 09:23:22 UTC 2015 - lslezak@suse.cz
+
+- fixed saving removed services (needed for FATE#315161)
+- 3.1.25
+
+-------------------------------------------------------------------
 Wed Jun 10 15:09:51 UTC 2015 - lslezak@suse.cz
 
 - added support for the file conflicts callbacks (bnc#923590)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.24
+Version:        3.1.25
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Libzypp raises an exception when removing a non-existing service, this causes `Pkg.SourceSaveAll()` to fail. We need to explicitly check whether the service file actually exists before removing it.

The patch fixes these situations:

- Repeated `Pkg.SourceSaveAll()` call failed after service removal as the removed services were still kept in memory.
- Adding a new service and removing it without saving caused the same problem at `Pkg.SourceSaveAll()` as the service file has not been created.

I found the issue during testing the [FATE#315161](https://fate.suse.com/315161) implementation.

- version 3.1.25