### PR TITLE
Pkg.SetSolverFlags(): added DUP mode solver settings (FATE319128)

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -10,6 +10,22 @@
 
 PKG_CHECK_MODULES([ZYPP], [libzypp])
 
+ZYPP_VERSION=`pkg-config --print-errors --modversion libzypp`
+if test -z "$ZYPP_VERSION"; then
+  ZYPP_VERSION="0.0.0"
+fi
+
+ZYPP_VERSION_MAJOR=`echo $ZYPP_VERSION | cut -d. -f1`
+ZYPP_VERSION_MINOR=`echo $ZYPP_VERSION | cut -d. -f2`
+ZYPP_VERSION_PATCH=`echo $ZYPP_VERSION | cut -d. -f3`
+
+AH_TEMPLATE([HAVE_ZYPP_DUP_FLAGS], [Define if libzypp provides solver flags for DUP mode])
+if test \
+  \( "$ZYPP_VERSION_MAJOR" -eq 15 -a "$ZYPP_VERSION_MINOR" -ge 9 \) -o \
+  "$ZYPP_VERSION_MAJOR" -ge 16; then
+  AC_DEFINE([HAVE_ZYPP_DUP_FLAGS], 1)
+fi
+
 AX_CHECK_DOCBOOK
 ## and generate the output
 @YAST2-OUTPUT@

--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.26
+Version:        3.1.27
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 10 09:03:39 UTC 2015 - lslezak@suse.cz
+
+- Pkg.SetSolverFlags(): added DUP mode solver settings, these are
+  different that the "normal" mode settings (FATE319128)
+- 3.1.27
+
+-------------------------------------------------------------------
 Thu Jul  2 18:21:06 UTC 2015 - lslezak@suse.cz
 
 - added "allowVendorChange" option to Pkg.SetSolverFlags() to

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.26
+Version:        3.1.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -1785,6 +1785,38 @@ void SaveProblemList(const zypp::ResolverProblemList &problems, const std::strin
     }
 }
 
+// pointers to a member function are quite tricky,
+// see https://isocpp.org/wiki/faq/pointers-to-members
+void set_solver_flag(zypp::Resolver_Ptr solver, const char *name, const YCPMap &params,
+    bool (zypp::Resolver::*get_ptr)() const, void (zypp::Resolver::*set_ptr)(bool),
+    void (zypp::Resolver::*reset_ptr)())
+{
+    YCPValue value(params->value(YCPString(name)));
+
+    if (!value.isNull())
+    {
+        // check for nil value
+        if (value->isVoid())
+        {
+            y2milestone("Resetting the '%s' flag to the default value", name);
+            // reset to default
+            ((*solver).*reset_ptr)();
+
+            // get the current value
+            bool value = ((*solver).*get_ptr)();
+            y2milestone("Solver flag '%s' is now %s", name, value ? "enabled" : "disabled");
+        }
+        else if (value->isBoolean())
+        {
+            bool new_value = value->asBoolean()->value();
+
+            y2milestone("Setting solver flag '%s' to %s", name, new_value ? "enabled" : "disabled");
+            // set the new value
+            ((*solver).*set_ptr)(new_value);
+        }
+    }
+}
+
 /**
    @builtin SetSolverFlags
    @short Set solver flags (options)
@@ -1812,152 +1844,69 @@ YCPValue PkgFunctions::SetSolverFlags(const YCPMap& params)
         return YCPBoolean(true);
     }
 
-    const YCPString vendor_key("allowVendorChange");
-    if (!params->value(vendor_key).isNull())
+    zypp::Resolver_Ptr solver = zypp_ptr()->resolver();
+    const YCPValue reset_value(params->value(YCPString("reset")));
+
+    if (!reset_value.isNull() && reset_value->isBoolean())
     {
-        // check for nil value
-        if (params->value(vendor_key)->isVoid())
-        {
-            y2milestone("Resetting the vendor change flag to the default value");
-            // reset to default
-            zypp_ptr()->resolver()->setDefaultAllowVendorChange();
-
-            bool allowed = zypp_ptr()->resolver()->allowVendorChange();
-            y2milestone("Vendor change is now %s", allowed ? "enabled" : "disabled");
-        }
-        else if (params->value(vendor_key)->isBoolean())
-        {
-            bool allow_change = params->value(vendor_key)->asBoolean()->value();
-
-            y2milestone("Vendor change set to %s", allow_change ? "enabled" : "disabled");
-            zypp_ptr()->resolver()->setAllowVendorChange(allow_change);
-        }
-    }
-
-    const YCPString reset_key("reset");
-    if (!params->value(reset_key).isNull() && params->value(reset_key)->isBoolean())
-    {
-	bool reset = params->value(reset_key)->asBoolean()->value();
+	bool reset = reset_value->asBoolean()->value();
 
 	if (reset)
 	{
 	    y2milestone("Resetting the solver");
-	    zypp_ptr()->resolver()->reset();
+	    solver->reset();
 	    // reset also the dist upgrade flag (set by PkgUpdateAll())
-	    zypp_ptr()->resolver()->setUpgradeMode(false);
+	    solver->setUpgradeMode(false);
 	}
     }
 
-    const YCPString ignore_key("ignoreAlreadyRecommended");
-    if (!params->value(ignore_key).isNull() && params->value(ignore_key)->isBoolean())
+    // there is no "reset to default" function, the set_solver_flag() wrapper
+    // cannot be used here :-(
+    const YCPValue ignore_value(params->value(YCPString("ignoreAlreadyRecommended")));
+    if (!ignore_value.isNull() && ignore_value->isBoolean())
     {
-	bool ignoreAlreadyRecommended = params->value(ignore_key)->asBoolean()->value();
+	bool ignoreAlreadyRecommended = ignore_value->asBoolean()->value();
 	y2milestone("Setting solver flag ignoreAlreadyRecommended: %d", ignoreAlreadyRecommended);
-	zypp_ptr()->resolver()->setIgnoreAlreadyRecommended(ignoreAlreadyRecommended);
+	solver->setIgnoreAlreadyRecommended(ignoreAlreadyRecommended);
     }
 
-    const YCPString requires_key("onlyRequires");
-    if (!params->value(requires_key).isNull() && params->value(requires_key)->isBoolean())
-    {
-	bool onlyRequires = params->value(requires_key)->asBoolean()->value();
-	y2milestone("Setting solver flag onlyRequires: %d", onlyRequires);
-	zypp_ptr()->resolver()->setOnlyRequires(onlyRequires);
-    }
+    set_solver_flag(solver, "allowVendorChange", params,
+        &zypp::Resolver::allowVendorChange,
+        &zypp::Resolver::setAllowVendorChange,
+        &zypp::Resolver::setDefaultAllowVendorChange);
+
+    set_solver_flag(solver, "onlyRequires", params,
+        &zypp::Resolver::onlyRequires,
+        &zypp::Resolver::setOnlyRequires,
+        &zypp::Resolver::resetOnlyRequires);
 
 // conditional compilation to not fail with a bit older libzypp
 #ifdef HAVE_ZYPP_DUP_FLAGS
     /* set DUP flags (the libzypp default for all values is 'true') */
-    const YCPString dup_vendor_key("dupAllowVendorChange");
-    if (!params->value(dup_vendor_key).isNull())
-    {
-        // check for nil value
-        if (params->value(dup_vendor_key)->isVoid())
-        {
-            y2milestone("Resetting the DUP vendor change flag to the default value");
-            // reset to default
-            zypp_ptr()->resolver()->dupSetDefaultAllowVendorChange();
 
-            bool allowed = zypp_ptr()->resolver()->dupAllowVendorChange();
-            y2milestone("DUP vendor change is now %s", allowed ? "enabled" : "disabled");
-        }
-        else if (params->value(dup_vendor_key)->isBoolean())
-        {
-            bool allow_change = params->value(dup_vendor_key)->asBoolean()->value();
+    set_solver_flag(solver, "dupAllowArchChange", params,
+        &zypp::Resolver::dupAllowArchChange,
+        &zypp::Resolver::dupSetAllowArchChange,
+        &zypp::Resolver::dupSetDefaultAllowArchChange);
 
-            y2milestone("DUP vendor change set to %s", allow_change ? "enabled" : "disabled");
-            zypp_ptr()->resolver()->dupSetAllowVendorChange(allow_change);
-        }
-    }
+    set_solver_flag(solver, "dupAllowDowngrade", params,
+        &zypp::Resolver::dupAllowDowngrade,
+        &zypp::Resolver::dupSetAllowDowngrade,
+        &zypp::Resolver::dupSetDefaultAllowDowngrade);
 
-    const YCPString dup_downgrade("dupAllowDowngrade");
-    if (!params->value(dup_downgrade).isNull())
-    {
-        // check for nil value
-        if (params->value(dup_downgrade)->isVoid())
-        {
-            y2milestone("Resetting the DUP downgrade flag to the default value");
-            // reset to default
-            zypp_ptr()->resolver()->dupSetDefaultAllowDowngrade();
+    set_solver_flag(solver, "dupAllowNameChange", params,
+        &zypp::Resolver::dupAllowNameChange,
+        &zypp::Resolver::dupSetAllowNameChange,
+        &zypp::Resolver::dupSetDefaultAllowNameChange);
 
-            bool allowed = zypp_ptr()->resolver()->dupAllowDowngrade();
-            y2milestone("DUP downgrade is now %s", allowed ? "enabled" : "disabled");
-        }
-        else if (params->value(dup_downgrade)->isBoolean())
-        {
-            bool allow_change = params->value(dup_downgrade)->asBoolean()->value();
-
-            y2milestone("DUP version downgrade set to %s", allow_change ? "enabled" : "disabled");
-            zypp_ptr()->resolver()->dupSetAllowDowngrade(allow_change);
-        }
-    }
-
-    const YCPString dup_name_change("dupAllowNameChange");
-    if (!params->value(dup_name_change).isNull())
-    {
-        // check for nil value
-        if (params->value(dup_name_change)->isVoid())
-        {
-            y2milestone("Resetting the DUP name change flag to the default value");
-            // reset to default
-            zypp_ptr()->resolver()->dupSetDefaultAllowNameChange();
-
-            bool allowed = zypp_ptr()->resolver()->dupAllowNameChange();
-            y2milestone("DUP name change is now %s", allowed ? "enabled" : "disabled");
-        }
-        else if (params->value(dup_name_change)->isBoolean())
-        {
-            bool allow_change = params->value(dup_name_change)->asBoolean()->value();
-
-            y2milestone("DUP name change set to %s", allow_change ? "enabled" : "disabled");
-            zypp_ptr()->resolver()->dupSetAllowNameChange(allow_change);
-        }
-    }
-
-    const YCPString dup_arch_change("dupAllowArchChange");
-    if (!params->value(dup_arch_change).isNull())
-    {
-        // check for nil value
-        if (params->value(dup_arch_change)->isVoid())
-        {
-            y2milestone("Resetting the DUP downgrade flag to the default value");
-            // reset to default
-            zypp_ptr()->resolver()->dupSetDefaultAllowArchChange();
-
-            bool allowed = zypp_ptr()->resolver()->dupAllowArchChange();
-            y2milestone("DUP downgrade is now %s", allowed ? "enabled" : "disabled");
-        }
-        else if (params->value(dup_arch_change)->isBoolean())
-        {
-            bool allow_change = params->value(dup_arch_change)->asBoolean()->value();
-
-            y2milestone("DUP version downgrade set to %s", allow_change ? "enabled" : "disabled");
-            zypp_ptr()->resolver()->dupSetAllowArchChange(allow_change);
-        }
-    }
+    set_solver_flag(solver, "dupAllowVendorChange", params,
+        &zypp::Resolver::dupAllowVendorChange,
+        &zypp::Resolver::dupSetAllowVendorChange,
+        &zypp::Resolver::dupSetDefaultAllowVendorChange);
 #else
 #warning "Pkg::SetSolverFlags: The solver flags for DUP mode are not supported!"
-  // just a warning, this new functionality is not critical...
-  y2warning("Pkg::SetSolverFlags: The solver flags for DUP mode are not supported!");
+    // just a warning, this new functionality is not critical...
+    y2warning("Pkg::SetSolverFlags: The solver flags for DUP mode are not supported!");
 #endif
 
     return YCPBoolean(true);
@@ -1987,8 +1936,8 @@ YCPValue PkgFunctions::GetSolverFlags()
     ret->add(YCPString("dupAllowVendorChange"), YCPBoolean(solver->dupAllowVendorChange()));
 #else
 #warning "Pkg::GetSolverFlags: The solver flags for DUP mode are not supported!"
-  // just a warning, this new functionality is not critical...
-  y2warning("Pkg::GetSolverFlags: The solver flags for DUP mode are not supported!");
+    // just a warning, this new functionality is not critical...
+    y2warning("Pkg::GetSolverFlags: The solver flags for DUP mode are not supported!");
 #endif
 
     return ret;

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -57,6 +57,10 @@ extern "C"
 #include <errno.h>
 }
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 /*
   Textdomain "pkg-bindings"
 */
@@ -1787,6 +1791,14 @@ void SaveProblemList(const zypp::ResolverProblemList &problems, const std::strin
    @param map params solver options, currently accepted options are:
    "allowVendorChange" : boolean or nil, (allow (true) or forbid (false)
       vendor change, nil = set the default value from zypp.conf file)
+   "dupAllowVendorChange" : boolean or nil, allow to change vendor of installed
+      solvable in the DUP mode (Pkg::PkgUpdateAll()), nil sets the default
+   "dupAllowArchChange"   : boolean or nil, allow to change architecture of
+      installed solvables in the DUP mode (nil sets the default)
+   "dupAllowNameChange"   : boolean or nil, allow to downgrade installed
+      solvable in the DUP mode (nil sets the default)
+   "dupAllowDowngrade"    : boolean or nil, allow to change name of installed
+      solvable in the DUP mode (nil sets the default)
    "ignoreAlreadyRecommended" : boolean, (do not select recommended packages for already installed packages)
    "onlyRequires" : boolean, (do not select recommended packages, recommended language packages, modalias packages...)
    "reset" : boolean - if set to true then the solver is reset (all added extra requires/conflicts added by user are removed, fixsystem mode is disabled, additional data about solver run are cleared)
@@ -1852,21 +1864,132 @@ YCPValue PkgFunctions::SetSolverFlags(const YCPMap& params)
 	zypp_ptr()->resolver()->setOnlyRequires(onlyRequires);
     }
 
+// conditional compilation to not fail with a bit older libzypp
+#ifdef HAVE_ZYPP_DUP_FLAGS
+    /* set DUP flags (the libzypp default for all values is 'true') */
+    const YCPString dup_vendor_key("dupAllowVendorChange");
+    if (!params->value(dup_vendor_key).isNull())
+    {
+        // check for nil value
+        if (params->value(dup_vendor_key)->isVoid())
+        {
+            y2milestone("Resetting the DUP vendor change flag to the default value");
+            // reset to default
+            zypp_ptr()->resolver()->dupSetDefaultAllowVendorChange();
+
+            bool allowed = zypp_ptr()->resolver()->dupAllowVendorChange();
+            y2milestone("DUP vendor change is now %s", allowed ? "enabled" : "disabled");
+        }
+        else if (params->value(dup_vendor_key)->isBoolean())
+        {
+            bool allow_change = params->value(dup_vendor_key)->asBoolean()->value();
+
+            y2milestone("DUP vendor change set to %s", allow_change ? "enabled" : "disabled");
+            zypp_ptr()->resolver()->dupSetAllowVendorChange(allow_change);
+        }
+    }
+
+    const YCPString dup_downgrade("dupAllowDowngrade");
+    if (!params->value(dup_downgrade).isNull())
+    {
+        // check for nil value
+        if (params->value(dup_downgrade)->isVoid())
+        {
+            y2milestone("Resetting the DUP downgrade flag to the default value");
+            // reset to default
+            zypp_ptr()->resolver()->dupSetDefaultAllowDowngrade();
+
+            bool allowed = zypp_ptr()->resolver()->dupAllowDowngrade();
+            y2milestone("DUP downgrade is now %s", allowed ? "enabled" : "disabled");
+        }
+        else if (params->value(dup_downgrade)->isBoolean())
+        {
+            bool allow_change = params->value(dup_downgrade)->asBoolean()->value();
+
+            y2milestone("DUP version downgrade set to %s", allow_change ? "enabled" : "disabled");
+            zypp_ptr()->resolver()->dupSetAllowDowngrade(allow_change);
+        }
+    }
+
+    const YCPString dup_name_change("dupAllowNameChange");
+    if (!params->value(dup_name_change).isNull())
+    {
+        // check for nil value
+        if (params->value(dup_name_change)->isVoid())
+        {
+            y2milestone("Resetting the DUP name change flag to the default value");
+            // reset to default
+            zypp_ptr()->resolver()->dupSetDefaultAllowNameChange();
+
+            bool allowed = zypp_ptr()->resolver()->dupAllowNameChange();
+            y2milestone("DUP name change is now %s", allowed ? "enabled" : "disabled");
+        }
+        else if (params->value(dup_name_change)->isBoolean())
+        {
+            bool allow_change = params->value(dup_name_change)->asBoolean()->value();
+
+            y2milestone("DUP name change set to %s", allow_change ? "enabled" : "disabled");
+            zypp_ptr()->resolver()->dupSetAllowNameChange(allow_change);
+        }
+    }
+
+    const YCPString dup_arch_change("dupAllowArchChange");
+    if (!params->value(dup_arch_change).isNull())
+    {
+        // check for nil value
+        if (params->value(dup_arch_change)->isVoid())
+        {
+            y2milestone("Resetting the DUP downgrade flag to the default value");
+            // reset to default
+            zypp_ptr()->resolver()->dupSetDefaultAllowArchChange();
+
+            bool allowed = zypp_ptr()->resolver()->dupAllowArchChange();
+            y2milestone("DUP downgrade is now %s", allowed ? "enabled" : "disabled");
+        }
+        else if (params->value(dup_arch_change)->isBoolean())
+        {
+            bool allow_change = params->value(dup_arch_change)->asBoolean()->value();
+
+            y2milestone("DUP version downgrade set to %s", allow_change ? "enabled" : "disabled");
+            zypp_ptr()->resolver()->dupSetAllowArchChange(allow_change);
+        }
+    }
+#else
+#warning "Pkg::SetSolverFlags: The solver flags for DUP mode are not supported!"
+  // just a warning, this new functionality is not critical...
+  y2warning("Pkg::SetSolverFlags: The solver flags for DUP mode are not supported!");
+#endif
+
     return YCPBoolean(true);
 }
 
 /**
    @builtin GetSolverFlags
    @short Get the current solver flags (options)
-   @return map<string,any> current options see @see SetSolverFlags, "reset" flag is write only
+   @return map<string,any> the current solver settings see @see SetSolverFlags,
+     the "reset" key is missing
 */
 YCPValue PkgFunctions::GetSolverFlags()
 {
     YCPMap ret;
+    zypp::Resolver_Ptr solver = zypp_ptr()->resolver();
 
-    ret->add(YCPString("onlyRequires"), YCPBoolean(zypp_ptr()->resolver()->onlyRequires()));
-    ret->add(YCPString("ignoreAlreadyRecommended"), YCPBoolean(zypp_ptr()->resolver()->ignoreAlreadyRecommended()));
-    ret->add(YCPString("allowVendorChange"), YCPBoolean(zypp_ptr()->resolver()->allowVendorChange()));
+    ret->add(YCPString("onlyRequires"), YCPBoolean(solver->onlyRequires()));
+    ret->add(YCPString("ignoreAlreadyRecommended"), YCPBoolean(solver->ignoreAlreadyRecommended()));
+    ret->add(YCPString("allowVendorChange"), YCPBoolean(solver->allowVendorChange()));
+
+// conditional compilation to not fail with a bit older libzypp
+#ifdef HAVE_ZYPP_DUP_FLAGS
+    // DUP mode flags
+    ret->add(YCPString("dupAllowDowngrade"), YCPBoolean(solver->dupAllowDowngrade()));
+    ret->add(YCPString("dupAllowNameChange"), YCPBoolean(solver->dupAllowNameChange()));
+    ret->add(YCPString("dupAllowArchChange"), YCPBoolean(solver->dupAllowArchChange()));
+    ret->add(YCPString("dupAllowVendorChange"), YCPBoolean(solver->dupAllowVendorChange()));
+#else
+#warning "Pkg::GetSolverFlags: The solver flags for DUP mode are not supported!"
+  // just a warning, this new functionality is not critical...
+  y2warning("Pkg::GetSolverFlags: The solver flags for DUP mode are not supported!");
+#endif
 
     return ret;
 }


### PR DESCRIPTION
...these are different that the "normal" mode settings.

- 3.1.27

---

Note: The new part is compiled conditionally only with a new libzypp. The reason is to avoid failure in [YaST:Head](https://build.opensuse.org/project/monitor/YaST:Head) for older build targets.

(Otherwise we would have to upgrade `libzypp`, `zypper`, `PackageKit`, ... and that would be a maintenance nightmare.)