### PR TITLE
Use zypp built-in asKind cast rather than assuming Resolvable::Ptr-ty…

### DIFF
--- a/src/Package.cc
+++ b/src/Package.cc
@@ -119,7 +119,7 @@ PkgFunctions::PkgQueryProvides( const YCPString& tag )
 	zypp::PoolItem provider = zypp::ResPool::instance().find(*iter);
 
 	// cast to Package object
-	zypp::Package::constPtr package = zypp::dynamic_pointer_cast<const zypp::Package>(provider.resolvable());
+	zypp::Package::constPtr package = zypp::asKind<zypp::Package>(provider.resolvable());
 
 	if (!package)
 	{
@@ -312,7 +312,7 @@ PkgFunctions::PkgMediaSizesOrCount (bool sizes, bool download_size)
     {
         if ((*it)->fate() == zypp::ui::Selectable::TO_INSTALL)
 	{
-	    zypp::Package::constPtr pkg = boost::dynamic_pointer_cast<const zypp::Package>((*it)->candidateObj().resolvable());
+	    zypp::Package::constPtr pkg = zypp::asKind<zypp::Package>((*it)->candidateObj().resolvable());
 
 	    if (!pkg)
 		continue;
@@ -731,7 +731,7 @@ static zypp::Package::constPtr find_package(const string &name)
 
     if (s)
     {
-	return zypp::dynamic_pointer_cast<const zypp::Package>(s->theObj().resolvable());
+	return zypp::asKind<zypp::Package>(s->theObj().resolvable());
     }
 
     return NULL;
@@ -870,7 +870,7 @@ PkgFunctions::PkgProp(const zypp::PoolItem &item)
 {
     YCPMap data;
 
-    zypp::Package::constPtr pkg = zypp::dynamic_pointer_cast<const zypp::Package>(item.resolvable());
+    zypp::Package::constPtr pkg = zypp::asKind<zypp::Package>(item.resolvable());
 
     if (pkg == NULL) {
 	y2error("NULL pkg");
@@ -1040,7 +1040,7 @@ PkgFunctions::PkgPath (const YCPString& p)
 // a helper function
 YCPList _create_filelist(const zypp::PoolItem &pi)
 {
-    zypp::Package::constPtr package = zypp::dynamic_pointer_cast<const zypp::Package>(pi.resolvable());
+    zypp::Package::constPtr package = zypp::asKind<zypp::Package>(pi.resolvable());
 
     YCPList ret;
 
@@ -1281,7 +1281,7 @@ PkgFunctions::IsManualSelection ()
 static void
 pkg2list (YCPList &list, const zypp::PoolItem &item, bool names_only)
 {
-    zypp::Package::constPtr pkg = zypp::dynamic_pointer_cast<const zypp::Package>(item.resolvable());
+    zypp::Package::constPtr pkg = zypp::asKind<zypp::Package>(item.resolvable());
 
     if (!pkg)
     {
@@ -2625,7 +2625,7 @@ YCPString PkgFunctions::PkgGetLicenseToConfirm( const YCPString & package )
 
 	    if (s && s->toInstall() && !s->hasLicenceConfirmed())
 	    {
-		zypp::Package::constPtr package = zypp::dynamic_pointer_cast<const zypp::Package>(s->candidateObj().resolvable());
+		zypp::Package::constPtr package = zypp::asKind<zypp::Package>(s->candidateObj().resolvable());
 		if (package)
 		{
 		    return YCPString(package->licenseToConfirm());
@@ -2758,8 +2758,7 @@ zypp::Product::constPtr PkgFunctions::FindInstalledBaseProduct()
                 res->arch() == base_product->arch)
 
 	    {
-		zypp::Product::constPtr product =
-                    boost::dynamic_pointer_cast<const zypp::Product>(res);
+		zypp::Product::constPtr product = res->asKind<zypp::Product>();
 
 		if (product)
 		{

--- a/src/Resolvable_Patches.cc
+++ b/src/Resolvable_Patches.cc
@@ -99,7 +99,7 @@ PkgFunctions::ResolvableSetPatches (const YCPSymbol& kind_r, bool preselect)
 
 	    if (s && s->isNeeded() && !s->isUnwanted())
 	    {
-		zypp::Patch::constPtr patch = zypp::dynamic_pointer_cast<const zypp::Patch>
+		zypp::Patch::constPtr patch = zypp::asKind<zypp::Patch>
 		    (s->candidateObj().resolvable());
 
 		// dont auto-install optional patches

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -264,7 +264,7 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, const std::st
     // package specific info
     if( req_kind == "package" )
     {
-	zypp::Package::constPtr pkg = boost::dynamic_pointer_cast<const zypp::Package>(item.resolvable());
+	zypp::Package::constPtr pkg = zypp::asKind<zypp::Package>(item.resolvable());
 	if ( pkg )
 	{
 	    std::string tmp = pkg->location().filename().asString();
@@ -285,7 +285,7 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, const std::st
     }
     else if( req_kind == "srcpackage" )
     {
-	zypp::SrcPackage::constPtr pkg = boost::dynamic_pointer_cast<const zypp::SrcPackage>(item.resolvable());
+	zypp::SrcPackage::constPtr pkg = zypp::asKind<zypp::SrcPackage>(item.resolvable());
 	if (pkg)
 	{
 	    std::string tmp(pkg->location().filename().asString());
@@ -309,7 +309,7 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, const std::st
     }
     // product specific info
     else if( req_kind == "product" ) {
-	zypp::Product::constPtr product = boost::dynamic_pointer_cast<const zypp::Product>(item.resolvable());
+	zypp::Product::constPtr product = zypp::asKind<zypp::Product>(item.resolvable());
 	if ( !product )
 	{
 	    y2error("product %s is not a product", item->name().c_str() );
@@ -510,7 +510,7 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, const std::st
     }
     // pattern specific info
     else if ( req_kind == "pattern" ) {
-	zypp::Pattern::constPtr pattern = boost::dynamic_pointer_cast<const zypp::Pattern>(item.resolvable());
+	zypp::Pattern::constPtr pattern = zypp::asKind<zypp::Pattern>(item.resolvable());
 	info->add(YCPString("category"), YCPString(pattern->category()));
 	info->add(YCPString("user_visible"), YCPBoolean(pattern->userVisible()));
 	info->add(YCPString("default"), YCPBoolean(pattern->isDefault()));
@@ -521,7 +521,7 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, const std::st
     // patch specific info
     else if ( req_kind == "patch" )
     {
-	zypp::Patch::constPtr patch_ptr = boost::dynamic_pointer_cast<const zypp::Patch>(item.resolvable());
+	zypp::Patch::constPtr patch_ptr = zypp::asKind<zypp::Patch>(item.resolvable());
 
 	info->add(YCPString("interactive"), YCPBoolean(patch_ptr->interactive()));
 	info->add(YCPString("reboot_needed"), YCPBoolean(patch_ptr->rebootSuggested()));

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -889,7 +889,7 @@ void PkgFunctions::RememberBaseProduct(const std::string &alias)
 	    // check the repository
 	    if (res && res->repoInfo().alias() == alias)
 	    {
-		zypp::Product::constPtr product = boost::dynamic_pointer_cast<const zypp::Product>(res);
+		zypp::Product::constPtr product = zypp::asKind<zypp::Product>(res);
 
 		if (product)
 		{

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -281,7 +281,7 @@ PkgFunctions::SourceMediaData (const YCPInteger& id)
 		aval_it != (*it)->availableEnd();
 		++aval_it)
 	    {
-		zypp::Package::constPtr pkg = boost::dynamic_pointer_cast<const zypp::Package>(aval_it->resolvable());
+		zypp::Package::constPtr pkg = zypp::asKind<zypp::Package>(aval_it->resolvable());
 
 		if (pkg && pkg->repoInfo().alias() == alias)
 		{
@@ -378,7 +378,7 @@ PkgFunctions::SourceProductData (const YCPInteger& src_id)
 		aval_it != (*it)->availableEnd();
 		++aval_it)
 	    {
-		zypp::Product::constPtr prod = boost::dynamic_pointer_cast<const zypp::Product>(aval_it->resolvable());
+		zypp::Product::constPtr prod = zypp::asKind<zypp::Product>(aval_it->resolvable());
 		if (prod && prod->repoInfo().alias() == alias)
 		{
 		    product = prod;


### PR DESCRIPTION
…pes are boost.

Your code will break once I change the underlying Resolvable::Ptr type.
Please fix this for Factory/SLE12-SP1.