### PR TITLE
Return the "product_line" product attribute (bsc#941402)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.27
+Version:        3.1.28
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 20 15:58:00 UTC 2015 - lslezak@suse.cz
+
+- return the "product_line" product attribute, needed for reading
+  an optional OEM release type (bsc#941402)
+- 3.1.28
+
+-------------------------------------------------------------------
 Fri Jul 10 09:03:39 UTC 2015 - lslezak@suse.cz
 
 - Pkg.SetSolverFlags(): added DUP mode solver settings, these are

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.27
+Version:        3.1.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -390,6 +390,7 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, const std::st
 	// registration data
 	info->add(YCPString("register_target"), YCPString(product->registerTarget()));
 	info->add(YCPString("register_release"), YCPString(product->registerRelease()));
+	info->add(YCPString("product_line"), YCPString(product->productLine()));
 
 	// Live CD, FTP Edition...
 	info->add(YCPString("flavor"), YCPString(product->flavor()));


### PR DESCRIPTION
needed for reading an optional OEM release type

- 3.1.28

Needed for the registration module to implement reading the product type the same way as in SUSEConnect (https://github.com/SUSE/connect/blob/master/lib/suse/connect/zypper/product.rb#L19)