### PR TITLE
Expose update notifications through PkgFunctions::CommitHelper

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.31
+Version:        3.1.32
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 15 10:49:39 UTC 2016 - igonzalezsosa@suse.com
+
+- Expose update notifications through PkgFunctions::CommitHelper
+- 3.1.32
+
+-------------------------------------------------------------------
 Thu Oct  8 21:07:44 UTC 2015 - igonzalezsosa@suse.com
 
 - Add pkgGpgCheck callback (bsc#948608)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.31
+Version:        3.1.32
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
* Adapt yast2-pkg-bindings to retrieve libzypp's update messages.
* First step to solve [bsc#943805](https://bugzilla.suse.com/show_bug.cgi?id=943805).