### PR TITLE
Provide package function

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.32
+Version:        3.1.33
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 29 12:32:18 UTC 2016 - igonzalezsosa@suse.com
+
+- Add a PkgProvidePackage to retrieve a package using
+  PackageProvider (fate#319716).
+- 3.1.33
+
+-------------------------------------------------------------------
 Mon Feb 15 10:49:39 UTC 2016 - igonzalezsosa@suse.com
 
 - Expose update notifications through PkgFunctions::CommitHelper

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Mar 29 12:32:18 UTC 2016 - igonzalezsosa@suse.com
 
-- Add a PkgProvidePackage to retrieve a package using
+- Add a Pkg::ProvidePackage to retrieve a package using
   PackageProvider (fate#319716).
 - 3.1.33
 

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.32
+Version:        3.1.33
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -2984,10 +2984,19 @@ YCPValue PkgFunctions::ProvidePackage(const YCPInteger & repo_id, const YCPStrin
   zypp::repo::PackageProviderPolicy packageProviderPolicy;
   zypp::repo::DeltaCandidates deltas;
   zypp::repo::PackageProvider pkgProvider(access, package, deltas, packageProviderPolicy);
-  zypp::ManagedFile file(pkgProvider.providePackage());
-  /* Copy the managed file to the given path */
-  std::ifstream src(file.value().asString(), std::ios::binary);
-  std::ofstream dest(path->value(), std::ios::binary);
-  dest << src.rdbuf();
+
+  try {
+    /* Retrieve the package */
+    zypp::ManagedFile file(pkgProvider.providePackage());
+    /* Copy the managed file to the given path */
+    std::ifstream src(file.value().asString(), std::ios::binary);
+    std::ofstream dest(path->value(), std::ios::binary);
+    dest << src.rdbuf();
+  }
+  catch (...) {
+    y2error("Package %s could not be downloaded", name->value().c_str());
+    return YCPBoolean(false);
+  }
+
   return YCPBoolean(true);
 }

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -2955,6 +2955,7 @@ YCPValue PkgFunctions::CreateSolverTestCase(const YCPString &dir)
 zypp::Package::constPtr PkgFunctions::packageFromRepo(const YCPInteger & repo_id, const YCPString & name) {
   zypp::ResPool pool(zypp::getZYpp()->pool());
   YRepo_Ptr repo = logFindRepository(repo_id->value());
+  if (!repo) return NULL;
 
   /* maybe we should use std::find_if */
   for_(it, pool.byIdentBegin<zypp::Package>(name->value()), pool.byIdentEnd<zypp::Package>(name->value())) {

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -2966,7 +2966,7 @@ zypp::Package::constPtr PkgFunctions::packageFromRepo(const YCPInteger & repo_id
 }
 
 /**
- * Provide a package using the \c zypp::repo::PackageProvuder class
+ * Provide a package using the \c zypp::repo::PackageProvider class
  *
  * @param YCPInteger   repo_id Repository ID (alias)
  * @param YCPString    name    Package name
@@ -2980,23 +2980,20 @@ zypp::Package::constPtr PkgFunctions::packageFromRepo(const YCPInteger & repo_id
 YCPValue PkgFunctions::ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPReference & func_r) {
 
   zypp::Package::constPtr package = packageFromRepo(repo_id, name);
+  if (package == NULL) return YCPBoolean(false);
 
-  if (package != NULL) {
-    zypp::repo::RepoMediaAccess access;
-    zypp::repo::PackageProviderPolicy packageProviderPolicy;
-    zypp::repo::DeltaCandidates deltas;
-    zypp::repo::PackageProvider pkgProvider(access, package, deltas, packageProviderPolicy);
-    zypp::ManagedFile file(pkgProvider.providePackage());
-    YCPString file_path(file.value().asString());
-    /* Callback execution */
-    SymbolEntryPtr ptr_sentry = func_r->entry();
-    Y2Namespace* ns = const_cast<Y2Namespace*> (ptr_sentry->nameSpace());
-    Y2Function* function_call = ns->createFunctionCall(ptr_sentry->name(),
-						       ptr_sentry->type());
-    function_call->appendParameter(file_path);
+  zypp::repo::RepoMediaAccess access;
+  zypp::repo::PackageProviderPolicy packageProviderPolicy;
+  zypp::repo::DeltaCandidates deltas;
+  zypp::repo::PackageProvider pkgProvider(access, package, deltas, packageProviderPolicy);
+  zypp::ManagedFile file(pkgProvider.providePackage());
+  YCPString file_path(file.value().asString());
+  /* Callback execution */
+  SymbolEntryPtr ptr_sentry = func_r->entry();
+  Y2Namespace* ns = const_cast<Y2Namespace*> (ptr_sentry->nameSpace());
+  Y2Function* function_call = ns->createFunctionCall(ptr_sentry->name(),
+                 ptr_sentry->type());
+  function_call->appendParameter(file_path);
 
-    return function_call->evaluateCall();
-  } else {
-    return YCPBoolean(false);
-  }
+  return function_call->evaluateCall();
 }

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -679,7 +679,7 @@ class PkgFunctions
 	YCPValue PkgReset ();
 	/* TYPEINFO: boolean()*/
 	YCPValue PkgApplReset ();
-        /* TYPEINFO: string(integer,string,string) */
+        /* TYPEINFO: boolean(integer,string,string) */
 	YCPValue ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPString & path);
 	/* TYPEINFO: map<string,any>()*/
 	YCPValue GetSolverFlags();

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -679,8 +679,8 @@ class PkgFunctions
 	YCPValue PkgReset ();
 	/* TYPEINFO: boolean()*/
 	YCPValue PkgApplReset ();
-        /* TYPEINFO: string(integer,string,reference) */
-	YCPValue ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPReference &func_r);
+        /* TYPEINFO: string(integer,string,string) */
+	YCPValue ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPString & path);
 	/* TYPEINFO: map<string,any>()*/
 	YCPValue GetSolverFlags();
 	/* TYPEINFO: boolean(map<string,any>)*/

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -221,6 +221,8 @@ class PkgFunctions
       // CommitPolicy used for commit
       zypp::ZYppCommitPolicy *commit_policy;
 
+      // getPackageFromRepo used for PkgFunctions::ProvidePackage
+      zypp::Package::constPtr packageFromRepo(const YCPInteger & repo_id, const YCPString & name);
     private:
 
       /**
@@ -677,6 +679,8 @@ class PkgFunctions
 	YCPValue PkgReset ();
 	/* TYPEINFO: boolean()*/
 	YCPValue PkgApplReset ();
+        /* TYPEINFO: string(string,string) */
+        YCPValue ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPReference &func_r);
 	/* TYPEINFO: map<string,any>()*/
 	YCPValue GetSolverFlags();
 	/* TYPEINFO: boolean(map<string,any>)*/

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -679,8 +679,8 @@ class PkgFunctions
 	YCPValue PkgReset ();
 	/* TYPEINFO: boolean()*/
 	YCPValue PkgApplReset ();
-        /* TYPEINFO: string(string,string) */
-        YCPValue ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPReference &func_r);
+        /* TYPEINFO: string(integer,string,reference) */
+	YCPValue ProvidePackage(const YCPInteger & repo_id, const YCPString & name, const YCPReference &func_r);
 	/* TYPEINFO: map<string,any>()*/
 	YCPValue GetSolverFlags();
 	/* TYPEINFO: boolean(map<string,any>)*/


### PR DESCRIPTION
Supporting https://github.com/yast/yast-installation/pull/356.
This is just a PoC to use `PackageProvider#providePackage` instead of `provideFile`. The objective is that libzypp takes care of checking the repository signature. I'm submitting this code because, frankly, I'm a little bit lost (and sure there's a better approach).

Needless to say that the code should be refactored, but I just want to discuss the approach.