### PR TITLE
fixed a benign warning

### DIFF
--- a/src/Callbacks.YCP.cc
+++ b/src/Callbacks.YCP.cc
@@ -104,6 +104,7 @@
 	ENUM_OUT( ProblemDeltaApply );
 	ENUM_OUT( FinishDeltaDownload );
 	ENUM_OUT( FinishDeltaApply );
+	ENUM_OUT( PkgGpgCheck );
 	ENUM_OUT( MediaChange );
 	ENUM_OUT( SourceChange );
 	ENUM_OUT( ResolvableReport );


### PR DESCRIPTION
A missing `case` in `switch` meant that a callback was identified only
by an internal number in a y2debug message.

warning: enumeration value ‘CB_PkgGpgCheck’ not handled in switch [-Wswitch]
