### PR TITLE
Added Pkg.UrlSchemeIs*() methods (bsc#948982)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.34
+Version:        3.2.0
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct  7 07:32:19 UTC 2016 - lslezak@suse.cz
+
+- Added Pkg.UrlSchemeIs*() methods for classifying the URL scheme
+  to avoid duplication of the libzypp code in YaST (bsc#948982)
+- 3.2.0
+
+-------------------------------------------------------------------
 Wed Apr  6 15:51:40 CEST 2016 - schubi@suse.de
 
 - Added new call: ServiceForceRefresh

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.34
+Version:        3.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,6 +52,7 @@ libpy2Pkg_la_SOURCES =				\
 	PkgService.cc PkgService.h		\
 	ServiceManager.cc ServiceManager.h	\
 	Service.cc				\
+	UrlUtils.cc				\
 	Network.cc				\
 	BaseProduct.h BaseProduct.cc		\
 	HelpTexts.h i18n.h log.h

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -810,6 +810,18 @@ class PkgFunctions
 	/* TYPEINFO: boolean(map<string,any>)*/
 	YCPValue SetZConfig(const YCPMap &cfg);
 
+    // URL related functions
+    /* TYPEINFO: list<string>() */
+    YCPValue UrlKnownSchemes();
+    /* TYPEINFO: boolean(string) */
+    YCPValue UrlSchemeIsRemote(const YCPString &url_scheme);
+    /* TYPEINFO: boolean(string) */
+    YCPValue UrlSchemeIsLocal(const YCPString &url_scheme);
+    /* TYPEINFO: boolean(string) */
+    YCPValue UrlSchemeIsVolatile(const YCPString &url_scheme);
+    /* TYPEINFO: boolean(string) */
+    YCPValue UrlSchemeIsDownloading(const YCPString &url_scheme);
+
         YCPValue ResolvablePropertiesEx(const YCPString& name, const YCPSymbol& kind_r, const YCPString& version, bool dependencies);
 	YCPValue ResolvableSetPatches(const YCPSymbol& kind_r, bool preselect);
 

--- a/src/UrlUtils.cc
+++ b/src/UrlUtils.cc
@@ -1,0 +1,85 @@
+/* ------------------------------------------------------------------------------
+ * Copyright (c) 2016 SUSE LLC
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of version 2 of the GNU General Public License as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * ------------------------------------------------------------------------------
+ */
+
+#include "PkgFunctions.h"
+#include "log.h"
+
+#include <zypp/Url.h>
+
+#include <ycp/YCPString.h>
+#include <ycp/YCPBoolean.h>
+#include <ycp/YCPList.h>
+
+/**
+ * @builtin UrlKnownSchemes
+ * @description Returns all URL schemes known to libzypp.
+ * @note The list contains *all* schemes which are known to libzypp.
+ *   The list contains also unsupported schemes (e.g. "sftp" which can be used
+ *   in repository URL, but the respective downloader is not implemented) or
+ *   schemes which not make sense for repositories (e.g. "mailto" or "ldap").
+ * @short URL schemes known by libzypp
+ * @return list of URL schemes
+ */
+YCPValue PkgFunctions::UrlKnownSchemes()
+{
+    YCPList list;
+    zypp::url::UrlSchemes schemes = zypp::Url::getRegisteredSchemes();
+
+    for(auto&& str: schemes) list->add(YCPString(str));
+
+    return list;
+}
+
+/**
+ * @builtin UrlSchemeIsRemote
+ * @short Is the URL scheme remote?
+ * @return true if the scheme is remote, false otherwise
+ */
+YCPValue PkgFunctions::UrlSchemeIsRemote(const YCPString &url_scheme)
+{
+    return YCPBoolean(zypp::Url::schemeIsRemote(url_scheme->value()));
+}
+
+/**
+ * @builtin UrlSchemeIsLocal
+ * @short Is the URL scheme local?
+ * @return true if the scheme is local, false otherwise
+ */
+YCPValue PkgFunctions::UrlSchemeIsLocal(const YCPString &url_scheme)
+{
+    return YCPBoolean(zypp::Url::schemeIsLocal(url_scheme->value()));
+}
+
+/**
+ * @builtin UrlSchemeIsVolatile
+ * @short Is the URL scheme volatile? I.e. the content can be changed by changing
+ * the medium in the drive even if the URL itself is unchanged.
+ * @return true if the scheme is volatile, false otherwise
+ */
+YCPValue PkgFunctions::UrlSchemeIsVolatile(const YCPString &url_scheme)
+{
+    return YCPBoolean(zypp::Url::schemeIsVolatile(url_scheme->value()));
+}
+
+/**
+ * @builtin UrlSchemeIsDownloading
+ * @short Do the files need to be downloaded locally before use or can be accessed directly?
+ * @return true if the scheme needs download, false otherwise
+ */
+YCPValue PkgFunctions::UrlSchemeIsDownloading(const YCPString &url_scheme)
+{
+    return YCPBoolean(zypp::Url::schemeIsDownloading(url_scheme->value()));
+}
+


### PR DESCRIPTION
... for classifying the URL scheme to avoid duplication of
the libzypp code in YaST.

- 3.2.0

This PR is related to https://github.com/yast/yast-packager/pull/193.