### PR TITLE
Fixed failure when trying to save a plugin service (bsc#1021117)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.1.31.1
+Version:        3.1.31.2
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 27 15:55:34 UTC 2017 - lslezak@suse.cz
+
+- Fixed failure when trying to save a plugin service (bsc#1021117)
+- 3.1.31.2
+
+-------------------------------------------------------------------
 Wed Apr  6 15:51:40 CEST 2016 - schubi@suse.de
 
 - Added new call: ServiceForceRefresh

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.1.31.1
+Version:        3.1.31.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Service.cc
+++ b/src/Service.cc
@@ -167,7 +167,11 @@ YCPValue PkgFunctions::ServiceSave(const YCPString &alias)
    @builtin ServiceGet
    @short Get detailed properties of a service
    @param alias alias of the service
-   @return map Service data in map $[ "alias":string, "name":string, "url":string, "autorefresh":boolean, "enabled":boolean, "file":string, "repos_to_disable" : list<string>, "repos_to_enable" : list<string> ]. "file" is name of the file from which the service has been read, it is empty if the service has not been saved yet
+   @return map Service data in map $[ "alias":string, "name":string, "url":string,
+   "autorefresh":boolean, "enabled":boolean, "file":string, "type":string,
+   "repos_to_disable" : list<string>, "repos_to_enable" : list<string> ]. "file"
+   is name of the file from which the service has been read, it is empty if the
+   service has not been saved yet
 */
 YCPValue PkgFunctions::ServiceGet(const YCPString &alias)
 {
@@ -186,6 +190,7 @@ YCPValue PkgFunctions::ServiceGet(const YCPString &alias)
     ret->add(YCPString("autorefresh"), YCPBoolean(s.autorefresh()));
     ret->add(YCPString("enabled"), YCPBoolean(s.enabled()));
     ret->add(YCPString("file"), YCPString(s.filepath().asString()));
+    ret->add(YCPString("type"), YCPString(s.type().asString()));
 
     if (s.reposToDisableSize() > 0)
     {

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -309,11 +309,18 @@ void ServiceManager::SavePkgService(PkgService &s_known, zypp::RepoManager &repo
 {
     const std::string alias(s_known.alias());
     const zypp::ServiceInfo s_stored = repomgr.getService(alias);
+    const std::string orig_alias(s_known.origAlias());
+
+    // plugin services cannot be saved, they are provided by a script
+    // https://doc.opensuse.org/projects/libzypp/SLE12SP1/zypp-services.html
+    if (s_stored.type() == zypp::repo::ServiceType::PLUGIN)
+    {
+        y2milestone("Not saving a plugin service: %s", orig_alias.c_str());
+        return;
+    }
 
     DBG << "Known Service: " << s_known << std::endl;
     DBG << "Stored Service: " << s_stored << std::endl;
-
-    std::string orig_alias(s_known.origAlias());
 
     y2debug("orig_alias: %s", orig_alias.c_str());
 


### PR DESCRIPTION
- 3.1.31.2

## Reproducing the Bug

- Save this to a `/usr/lib/zypp/plugins/services/test` file:
```bash
#! /bin/bash

cat << EOF
[test-repo]
name=test-repo
enabled=0
autorefresh=0
baseurl=http://example.com
type=rpm-md
keeppackages=0
EOF
```
- Add execution flag (`chmod a+x /usr/lib/zypp/plugins/services/test`)
- `zypper ls` should display a `test` service and `zypper lr` should display a `test:test-repo` repository
- Running `yast2 repositories` should fail after pressing `OK`

## The Fix

After applying the patch the saving the repositories should not fail anymore.