### PR TITLE
Return valid repository signature flag (bsc#1009127)

### DIFF
--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 29 15:29:51 UTC 2017 - lslezak@suse.cz
+
+- Return the repository signature flag status in the
+  Pkg.SourceGeneralData call (might be used for bsc#1009127)
+
+-------------------------------------------------------------------
 Wed Oct 12 16:24:12 UTC 2016 - lslezak@suse.cz
 
 - Added Pkg.SourceSetPriority() to allow changing the priority

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -32,6 +32,7 @@
 #include <zypp/Product.h>
 #include <zypp/Repository.h>
 #include <zypp/media/CredentialManager.h>
+#include <zypp/TriBool.h>
 
 #include <ycp/YCPBoolean.h>
 #include <ycp/YCPMap.h>
@@ -115,6 +116,7 @@ PkgFunctions::SourceGetCurrent (const YCPBoolean& enabled)
  * "service"	: YCPString, (service to which the repo belongs, empty if there is no service assigned)
  * "keeppackages" : YCPBoolean,
  * "is_update_repo" : YCPBoolean, (true if this is an update repo - this requires loaded objects in pool otherwise the flag is not returned! The value is stored in repo metadata, not in .repo file!)
+ * "valid_repo_signature" : YCPBoolean or YCPVoid (boolean: whether the repo metadata are signed and valid, nil: unsigned metadata)
  * ];
  *
  * </code>
@@ -162,6 +164,12 @@ PkgFunctions::SourceGeneralData (const YCPInteger& id)
     data->add( YCPString("service"),	YCPString(repo->repoInfo().service()));
 
     data->add( YCPString("keeppackages"),	YCPBoolean(repo->repoInfo().keepPackages()));
+
+    // handle tribool, return nil for the indeterminate state
+    if (zypp::indeterminate(repo->repoInfo().validRepoSignature()))
+        data->add(YCPString("valid_repo_signature"), YCPVoid());
+    else
+        data->add(YCPString("valid_repo_signature"), (YCPBoolean(repo->repoInfo().validRepoSignature())));
 
     // add Repository data
     zypp::Repository repository(zypp::ResPool::instance().reposFind(repo->repoInfo().alias()));

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -116,7 +116,7 @@ PkgFunctions::SourceGetCurrent (const YCPBoolean& enabled)
  * "service"	: YCPString, (service to which the repo belongs, empty if there is no service assigned)
  * "keeppackages" : YCPBoolean,
  * "is_update_repo" : YCPBoolean, (true if this is an update repo - this requires loaded objects in pool otherwise the flag is not returned! The value is stored in repo metadata, not in .repo file!)
- * "valid_repo_signature" : YCPBoolean or YCPVoid (boolean: whether the repo metadata are signed and valid, nil: unsigned metadata)
+ * "valid_repo_signature" : YCPBoolean or YCPVoid (boolean: nil=unsigned, false=bad signature, true=good signature)
  * ];
  *
  * </code>


### PR DESCRIPTION
To allow checking the repository metadata status.

See [bug 1009127](https://bugzilla.suse.com/show_bug.cgi?id=1009127) for more details.