### PR TITLE
Fix pkgGpgCheck callback crashing when reporting SrcPackages (bsc#1037210)

### DIFF
--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -728,12 +728,16 @@ namespace ZyppRecipients {
       YCPMap data;
 
       if (callback._set) {
-        // Package
-        const zypp::Package::constPtr & package_r = userData_r.get<zypp::Package::constPtr>("Package");
-        YCPString package = userData_r.get<std::string>("Package", package_r->name());
+        // Package or SrcPackage (ResObject is common base class)
+	zypp::ResObject::constPtr resobject_r;
+	if ( userData_r.hasvalue( "ResObject" ) )
+	  resobject_r = userData_r.get<zypp::ResObject::constPtr>( "ResObject" );
+	else // legacy callback sending "zypp::Package::constPtr "Package"
+	  resobject_r = userData_r.get<zypp::Package::constPtr>("Package");
+        YCPString package = resobject_r->name();
         data->add(YCPString("Package"), package);
 
-        const zypp::RepoInfo repo = package_r->repoInfo();
+        const zypp::RepoInfo repo = resobject_r->repoInfo();
         const std::string url = repo.rawUrl().asString();
         data->add(YCPString("RepoMediaUrl"), YCPString(url));
 


### PR DESCRIPTION
`Zypp::DownloadResolvableReport` may in fact be triggered as well when downloading `SrcPackage`s. Unfortunately we did not keep this in mind when defining the [pkgGpgCheck callbacks UserData](https://github.com/openSUSE/libzypp/blob/master/zypp/ZYppCallbacks.h#L174). 

When processing a `SrcPackage`, the  `<zypp::Package::constPtr>("Package")`  you try to retrieve from the UserData is a `nullptr`. Your code is not prepared for this and will crash.

Future libzypp versions will send a `<zypp::ResObject::constPtr>( "ResObject" )` instead. As `ResObject` is the common base class for all resolvable types, the value will always be present in the UserData and never be a `nullptr`.

The patch here should be applied ASAP to all your branches using 'libzypp-16.x' (Tumbleweed, SLE12-SP{2,3}, LEAP-42.{2,3}). Then to the older SLE12-(SP1,GA}, LEAP-42.1.