### PR TITLE
Do not crash when the repository URL is not defined (bsc#1043218)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.2.3
+Version:        3.2.4
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 21 12:16:39 UTC 2017 - lslezak@suse.cz
+
+- Do not crash when the repository URL is not defined (bsc#1043218)
+- 3.2.4
+
+-------------------------------------------------------------------
 Fri Jun  2 08:42:12 UTC 2017 - igonzalezsosa@suse.com
 
 - Fix pkgGpgCheck callback crashing when reporting SrcPackages

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.2.3
+Version:        3.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -1464,14 +1464,7 @@ namespace ZyppRecipients {
 	    if (callback._set)
 	    {
 		callback.addInt(_pkg_ref.logFindAlias(repo.alias()));
-
-		std::string url;
-		if (repo.baseUrlsBegin() != repo.baseUrlsEnd())
-		{
-		    url = repo.baseUrlsBegin()->asString();
-		}
-
-		callback.addStr(url);
+		callback.addStr(repo.url().asString());
 		callback.addStr(task.name());
 
 		callback.evaluate();
@@ -1528,14 +1521,7 @@ namespace ZyppRecipients {
 	    {
 		// search Yast source ID
 		callback.addInt(_pkg_ref.logFindAlias(source.info().alias()));
-
-		std::string url;
-		if (source.info().baseUrlsBegin() != source.info().baseUrlsEnd())
-		{
-		    url = source.info().baseUrlsBegin()->asString();
-		}
-
-		callback.addStr(url);
+		callback.addStr(source.info().url().asString());
 		callback.addSymbol(SrcReportErrorAsString(error));
 		callback.addStr(description);
 
@@ -1564,14 +1550,7 @@ namespace ZyppRecipients {
 	    {
 		// search Yast source ID
 		callback.addInt(_pkg_ref.logFindAlias(source.info().alias()));
-
-		std::string url;
-		if (source.info().baseUrlsBegin() != source.info().baseUrlsEnd())
-		{
-		    url = source.info().baseUrlsBegin()->asString();
-		}
-		callback.addStr(url);
-
+		callback.addStr(source.info().url().asString());
 		callback.addStr(task);
 		callback.addSymbol(SrcReportErrorAsString(error));
 		callback.addStr(reason);

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -230,11 +230,7 @@ PkgFunctions::PkgMediaNames ()
 		    y2warning("Name of repository '%lld' is empty, using URL", index);
 
 		    // use URL as the product name
-		    std::string name;
-		    if ((*repoit)->repoInfo().baseUrlsBegin() != (*repoit)->repoInfo().baseUrlsEnd())
-		    {
-			name = (*repoit)->repoInfo().baseUrlsBegin()->asString();
-		    }
+		    std::string name((*repoit)->repoInfo().url().asString());
 
 		    // use alias if url is unknown
 		    if (name.empty())

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -302,7 +302,7 @@ PkgFunctions::createManagedSource( const zypp::Url & url_r,
 
     y2milestone("Added source '%s': '%s', enabled: %s, autorefresh: %s",
 	repo.alias().c_str(),
-	repo.baseUrlsBegin()->asString().c_str(),
+	repo.url().asString().c_str(),
 	repo.enabled() ? "true" : "false",
 	repo.autorefresh() ? "true" : "false"
     );

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -283,9 +283,9 @@ PkgFunctions::SourceMediaData (const YCPInteger& id)
     y2warning("Pkg::SourceMediaData() doesn't return \"media_id\" and \"media_vendor\" values anymore.");
 
     // SourceMediaData returns URLs without password
-    if (repo->repoInfo().baseUrlsBegin() != repo->repoInfo().baseUrlsEnd())
+    if (!repo->repoInfo().baseUrlsEmpty())
     {
-	data->add( YCPString("url"),	YCPString(repo->repoInfo().baseUrlsBegin()->asString()));
+	data->add( YCPString("url"),	YCPString(repo->repoInfo().url().asString()));
 
 	// add all base URLs
 	YCPList base_urls;

--- a/src/Source_Resolvables.cc
+++ b/src/Source_Resolvables.cc
@@ -71,7 +71,7 @@ bool PkgFunctions::LoadResolvablesFrom(YRepo_Ptr repo, const zypp::ProgressData:
     prog.sendTo(progressrcv);
     zypp::CombinedProgressData load_subprogress(prog, 100);
 
-    try 
+    try
     {
 	zypp::RepoManager* repomanager = CreateRepoManager();
 	bool refresh = true;
@@ -84,15 +84,23 @@ bool PkgFunctions::LoadResolvablesFrom(YRepo_Ptr repo, const zypp::ProgressData:
 	    {
 		if (network_check)
 		{
-		    zypp::Url url = *(repoinfo.baseUrlsBegin());
+            if (repoinfo.baseUrlsEmpty())
+            {
+                y2milestone("No URL defined, skipping repository '%s'", repoinfo.alias().c_str());
+                refresh = false;
+            }
+            else
+            {
+                zypp::Url url = repoinfo.url();
 
-		    if (remoteRepo(url) && !NetworkDetected())
-		    {
-			y2warning("No network connection, skipping autorefresh of remote repository %s (%s)",
-			    repoinfo.alias().c_str(), url.asString().c_str());
+                if (remoteRepo(url) && !NetworkDetected())
+                {
+                    y2warning("No network connection, skipping autorefresh of remote repository %s (%s)",
+                    repoinfo.alias().c_str(), url.asString().c_str());
 
-			refresh = false;
-		    }
+                    refresh = false;
+                }
+            }
 		}
 
 		if (refresh)

--- a/src/YRepo.cc
+++ b/src/YRepo.cc
@@ -52,8 +52,8 @@ zypp::MediaSetAccess_Ptr & YRepo::mediaAccess()
     if (!_maccess)
     {
         y2milestone("Creating new MediaSetAccess for url %s",
-            (*_repo.baseUrlsBegin()).asString().c_str());
-        _maccess = new zypp::MediaSetAccess(_repo.name(), *_repo.baseUrlsBegin()); // FIXME handle multiple baseUrls
+            _repo.url().asString().c_str());
+        _maccess = new zypp::MediaSetAccess(_repo.name(), _repo.url()); // FIXME handle multiple baseUrls
     }
 
     return _maccess;


### PR DESCRIPTION
- A repository actually might not define the URL, normally this is not the case, but users can manually tweak the .repo file. In that case YaST still should not crash.
- See [this bugzilla comment](https://bugzilla.suse.com/show_bug.cgi?id=1043218#c3) for more details.


### Note

`RepoInfo::url()` is a shortcut for `baseUrlsEmpty() ? Url() : *baseUrlsBegin())`, i.e. returns empty URL if the repo does not define it. This can simplify the code a bit, see the details [here](https://github.com/openSUSE/libzypp/blob/master/zypp/RepoInfo.h#L132).