### PR TITLE
Keep enabled recommended packages (bsc#1059065)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.3.2
+Version:        4.0.0
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 22 07:24:54 UTC 2017 - lslezak@suse.cz
+
+- Keep enabled recommended packages for the next solver runs
+  when doing distribution upgrade (bsc#1059065)
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Aug 23 14:24:20 UTC 2017 - igonzalezsosa@suse.com
 
 - Rename PrdMarkLicenseUnconfirmed to PrdMarkLicenseNotConfirmed

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.3.2
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -1470,18 +1470,17 @@ PkgFunctions::GetPackages(const YCPSymbol& y_which, const YCPBoolean& y_names_on
 
 /**
  * @builtin PkgUpdateAll
- * @param map<string,any> update_options Options for the solver. All parameters are optional,
- *	if a parameter is missing the default value from the package manager (libzypp) is used.
- *	Currently supported options: <tt>NONE</tt>
+ * @param map<string,any> update_options obsolete, not used anymore
  *
  * @short Update installed packages
  * @description
  * Perform a distribution upgrade. This function solves
  * dependencies.
  *
- * Symbols and integer values returned: <tt>NONE</tt>
+ * Note: Changes the recommended packages solver flag, enables installing
+ * the recommended packages even for the following solver runs.
  *
- * @return map<symbol,integer> summary of the update
+ * @return map<symbol,integer> obsolete, empty map now
  */
 
 YCPValue
@@ -1513,28 +1512,19 @@ PkgFunctions::PkgUpdateAll (const YCPMap& options)
 	y2error("'keep_installed_patches' flag is obsoleted and should not be used, check the code!");
     }
 
-
-    YCPMap data;
-
     try
     {
-	// store the current ignoreAlreadyRecommended flag
-	bool ignore_recommended_bak = zypp_ptr()->resolver()->ignoreAlreadyRecommended();
 	// in full distupgrade enable recommended packages - zypper compatibility
 	y2milestone("Setting ignoreAlreadyRecommended to false");
 	zypp_ptr()->resolver()->setIgnoreAlreadyRecommended(false);
 
 	// solve upgrade, get statistics
 	zypp_ptr()->resolver()->doUpgrade();
-
-	// set the original flag
-	y2milestone("Reverting ignoreAlreadyRecommended to: %s", ignore_recommended_bak ? "true" : "false");
-	zypp_ptr()->resolver()->setIgnoreAlreadyRecommended(ignore_recommended_bak);
     }
     catch (...)
     {}
 
-    return data;
+    return YCPMap();
 }
 
 


### PR DESCRIPTION
for the next solver runs when doing distribution upgrade.

See more details in https://bugzilla.suse.com/show_bug.cgi?id=1059065#c19

- 4.0.0