### PR TITLE
Added simple smoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_install:
 script:
   # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
   # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
-  - docker run -it yast-pkg-bindings-image yast-travis-cpp
+  # run additional smoke tests to check the basic functionality
+  - docker run -it yast-pkg-bindings-image bash -c "yast-travis-cpp && ./smoke_test_prepare.sh && ./smoke_test_run.rb"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM yastdevel/cpp
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  libzypp-devel
+  libzypp-devel yast2-ruby-bindings
 COPY . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM yastdevel/cpp
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  libzypp-devel yast2-ruby-bindings
+  libzypp-devel yast2-ruby-bindings iproute2
 COPY . /usr/src/app
 

--- a/smoke_test_prepare.sh
+++ b/smoke_test_prepare.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# exit on error immediately
+set -e -x
+
+# install the built package
+# Note: use zypper if the dependencies are really required:
+# zypper --non-interactive in --no-recommends /usr/src/packages/RPMS/*/*.rpm
+rpm -iv --force --nodeps /usr/src/packages/RPMS/*/*.rpm
+
+# clear the log if present, it will be checked later
+rm -f /var/log/YaST2/y2log

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -1,0 +1,75 @@
+#! /usr/bin/env ruby
+
+# the used y2log file
+def log_file
+  Process.uid.zero? ? "/var/log/YaST2/y2log" : "#{ENV["HOME"]}/.y2log"
+end
+
+# ASAP, initializing YaST does some logging!
+raise "Non empty #{log_file} log file found!" if File.size?(log_file)
+
+require "yast"
+# import the pkg-bindings module
+Yast.import "Pkg"
+
+# grep y2log for errors, this is a bit fragile but some YaST errors go only
+# to y2log without affecting the return value :-(
+def check_y2log
+  y2log = File.read(log_file).split("\n")
+  
+  # keep only errors and higher
+  y2log.select! { |l| l =~ /^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} <[3-5]>/ }
+
+  # ignore internal libzypp exceptions when probing the /media.1/media file
+  y2log.reject! { |l| l =~ /\/media.1\/media/ }
+  # empty exception line following the previous error
+  y2log.reject! { |l| l =~ /Exception.cc\(log\):[0-9]+\s*$/ }
+
+  # ignore "Can't openfile '/var/lib/zypp/LastDistributionFlavor' for writing"
+  # (when running as non-root)
+  y2log.reject! { |l| l =~ /\/var\/lib\/zypp\/LastDistributionFlavor/ }
+  
+  if !y2log.empty?
+    puts "Found errors in #{log_file}:"
+    puts y2log
+    raise "Found errors in y2log!"
+  end
+end
+
+# Initialize the target, you can use Installation.destdir instead
+# of the hardcoded "/" path.
+puts "Checking Pkg.TargetInitialize..."
+raise "Pkg.TargetInitialize failed!" unless Yast::Pkg.TargetInitialize("/")
+puts "OK"
+
+# Load the installed packages into the pool.
+puts "Checking Pkg.TargetLoad..."
+raise "Pkg.TargetLoad failed!" unless Yast::Pkg.TargetLoad
+puts "OK"
+
+# Load the repository configuration. Refreshes the repositories if needed.
+puts "Checking Pkg.SourceRestore..."
+raise "Pkg.SourceRestore failed!" unless Yast::Pkg.SourceRestore
+puts "OK"
+
+# Load the available packages in the repositories to the pool.
+puts "Checking Pkg.SourceLoad..."
+raise "Pkg.SourceLoad failed!" unless Yast::Pkg.SourceLoad
+puts "OK"
+
+# Check all repositories - this expects at least one repo is defined in the system
+puts "Checking Pkg.SourceGetCurrent..."
+repos = Yast::Pkg.SourceGetCurrent(false)
+raise "Pkg.SourceGetCurrent failed!" unless repos
+raise "No repository found!" if repos.empty?
+puts "OK (found #{repos.size} repositories)"
+
+# Check all packages - this expects at least one package is available/installed
+puts "Checking Pkg.ResolvableProperties..."
+packages = Yast::Pkg.ResolvableProperties("", :package, "")
+raise "Pkg.ResolvableProperties failed!" unless packages
+raise "No package found!" if packages.empty?
+puts "OK (found #{packages.size} packages)"
+
+# scan y2log for errors
+check_y2log


### PR DESCRIPTION
To avoid bugs like https://github.com/yast/yast-pkg-bindings/pull/84/files

### Notes

- A simple smoke test, nothing fancy, just to catch the bugs earlier
- Unfortunately that specific bug makes it a bit complicated as it was only logged into `y2log` without any other effect
- Can be started also as a non-root (but needs `zypper ref` by `root` in advance), for easy testing during development
- Failed result to demonstrate the functionality: https://travis-ci.org/yast/yast-pkg-bindings/builds/279625833#L1597-L1614
- Green after merging `master` with the fix: https://travis-ci.org/yast/yast-pkg-bindings/builds/279639209#L1606-L1617