### PR TITLE
Do not crash after a callback is set, unset, then called

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 23 11:57:37 UTC 2017 - mvidner@suse.com
+
+- Do not crash after a callback is set, unset, then called
+  (bsc#1063459)
+- 4.0.2
+
+-------------------------------------------------------------------
 Mon Sep 25 10:30:05 UTC 2017 - igonzalezsosa@suse.com
 
 - Add a CompareVersions function (related to fate#323273)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Callbacks.YCP.cc
+++ b/src/Callbacks.YCP.cc
@@ -189,15 +189,21 @@
 	const _cbdata_t::const_iterator tmp1 = _cbdata.find(id_r);
 
 	if (tmp1 == _cbdata.end())
+	{
+	    y2debug ("Callback %s not found", cbName(id_r).c_str());
 	    return NULL;
+	}
+	if (tmp1->second.empty())
+	{
+	    y2debug ("Callback %s is empty", cbName(id_r).c_str());
+	    return NULL;
+	}
 
 	const YCPReference func(tmp1->second.top());
 
 	if (func.isNull() || ! func->isReference())
 	{
-	    // TODO
-//	    ycp2error ("Unexpected function pointer: %s"
-//		, ptr.isNull () ? "NULL" : ptr->toString ().c_str ());
+	    y2debug ("Callback %s is not a func reference", cbName(id_r).c_str());
 	    return NULL;
 	}
 


### PR DESCRIPTION
- [bsc#1063459](https://bugzilla.suse.com/show_bug.cgi?id=1063459) "Installer dies during installation on 512MB RAM"
- https://trello.com/c/pNoUdFif

I have tested that this makes the installation pass, yay