### PR TITLE
Report error when repository refresh fails (bsc#1064210)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ config.status
 config.sub
 configure
 configure.ac
+compile
 depcomp
 install-sh
 *.pot

--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 24 14:51:16 UTC 2017 - lslezak@suse.cz
+
+- Report error when repository refresh fails during a service
+  refresh (bsc#1064210)
+- 4.0.3
+
+-------------------------------------------------------------------
 Mon Oct 23 11:57:37 UTC 2017 - mvidner@suse.com
 
 - Do not crash after a callback is set, unset, then called

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Report error when repository refresh fails during a service refresh, do not hide the errors
- Related to [bsc#1064210](https://bugzilla.suse.com/show_bug.cgi?id=1064210)
- Tested manually with a fake broken service
- 4.0.3