### PR TITLE
Fixed Pkg.ExpandedUrl to return also the password (bsc#1067007)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  7 12:03:48 UTC 2017 - lslezak@suse.cz
+
+- Fixed Pkg.ExpandedUrl to return also the password part
+  of the URL (bsc#1067007)
+- 4.0.5
+
+-------------------------------------------------------------------
 Fri Oct 27 14:40:23 UTC 2017 - lslezak@suse.cz
 
 - Pkg.ResolvableProperties: return the "register_flavor" product

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -71,5 +71,14 @@ raise "Pkg.ResolvableProperties failed!" unless packages
 raise "No package found!" if packages.empty?
 puts "OK (found #{packages.size} packages)"
 
+# make sure no URL part is lost by Pkg.ExpandedUrl call (bsc#1067007)
+puts "Checking Pkg.ExpandedUrl..."
+url = "https://user:pwd@example.com/path?opt=value"
+expanded_url = Yast::Pkg.ExpandedUrl(url)
+if url != expanded_url
+  raise "Unexpected result: #{expanded_url.inspect}, expected #{url.inspect}"
+end
+puts "OK"
+
 # scan y2log for errors
 check_y2log

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -518,7 +518,8 @@ YCPValue PkgFunctions::ExpandedUrl(const YCPString &url)
 
     zypp::RepoVariablesReplacedUrl replacedUrl;
     replacedUrl.raw() = zypp::Url(url->asString()->value());
-    return YCPString(replacedUrl.transformed().asString());
+    // return full URL including the password if present
+    return YCPString(replacedUrl.transformed().asCompleteString());
 }
 
 /**


### PR DESCRIPTION
- The password in URL was lost after calling `Pkg.ExpandedUrl`
- See https://bugzilla.suse.com/show_bug.cgi?id=1067007
- Added a smoke test for this Pkg call

Note: libzypp by default omits the password in `zypp::Url::asString()`method for security reasons. The password is not logged to `y2log` or displayed in the UI or in terminal by mistake.

However, in some cases you really need the full URL. In that case you have to use the `zypp::Url::asCompleteString()` method instead.