### PR TITLE
Log more details in PkgQueryProvides call

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 24 11:52:55 UTC 2018 - lslezak@suse.cz
+
+- Log more details in PkgQueryProvides call
+  (related to bsc#1072634)
+- 4.0.6
+
+-------------------------------------------------------------------
 Thu Dec  7 12:03:48 UTC 2017 - lslezak@suse.cz
 
 - Fixed Pkg.ExpandedUrl to return also the password part

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -34,6 +34,7 @@
 #include <ycp/YCPMap.h>
 
 #include <ycp/Type.h>
+#include <y2util/Y2SLog.h>
 
 #include <zypp/base/Algorithm.h>
 #include <zypp/ResFilters.h>
@@ -118,6 +119,8 @@ PkgFunctions::PkgQueryProvides( const YCPString& tag )
     zypp::Capability cap(name, zypp::ResKind::package);
     zypp::sat::WhatProvides possibleProviders(cap);
 
+    y2milestone("Searching packages providing: %s", name.c_str());
+
     for_(iter, possibleProviders.begin(), possibleProviders.end())
     {
 	zypp::PoolItem provider = zypp::ResPool::instance().find(*iter);
@@ -132,6 +135,8 @@ PkgFunctions::PkgQueryProvides( const YCPString& tag )
 	}
 
 	std::string pkgname = package->name();
+
+        MIL << "Found package: " << package << std::endl;
 
 	// get instance status
 	bool installed = provider.status().staysInstalled();


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1072634

### Example

After calling e.g. `Yast::Pkg.PkgQueryProvides("yast2")` the `y2log` contains:

```
Package.cc(PkgQueryProvides):139 Found package: (2663)yast2-4.0.35-1.1.x86_64(@System)
Package.cc(PkgQueryProvides):139 Found package: (3422)yast2-4.0.35-1.1.i586(YaST)
Package.cc(PkgQueryProvides):139 Found package: (3424)yast2-4.0.35-1.1.x86_64(YaST)
Package.cc(PkgQueryProvides):139 Found package: (24672)yast2-4.0.35-1.1.i586(download.opensuse.org-oss)
Package.cc(PkgQueryProvides):139 Found package: (62316)yast2-4.0.35-1.1.x86_64(download.opensuse.org-oss)
```

The last value in parenthesis is the repository alias (or `@System` if the package is installed in the system).

@jreidinger : is that enough for debugging?