### PR TITLE
Ignore notification exception for failed plugin services (bsc#1086768)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May 16 16:07:27 UTC 2018 - lslezak@suse.cz
+
+- Ignore notification exception for failed plugin services,
+  avoid errors when refreshing the zypp-plugin-spacewalk service
+  on a system not managed by spacewalk (SUSE Manager)
+  (bsc#1086768)
+- 4.0.10
+
+-------------------------------------------------------------------
 Fri Feb 16 08:01:39 UTC 2018 - jsrain@suse.cz
 
 - always scan media for products to allow media identification

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -117,13 +117,23 @@ bool ServiceManager::RefreshService(const std::string &alias, zypp::RepoManager 
 	return false;
     }
 
-    if (force)
+    try
     {
-        repomgr.refreshService(serv_it->second, zypp::RepoManager::RefreshService_forceRefresh);
+        if (force)
+        {
+            repomgr.refreshService(serv_it->second, zypp::RepoManager::RefreshService_forceRefresh);
+        }
+        else
+        {
+            repomgr.refreshService(serv_it->second);
+        }
     }
-    else
+    // this is rather a notification from libzypp, not a real exception
+    catch (const zypp::repo::ServicePluginInformalException& excpt)
     {
-        repomgr.refreshService(serv_it->second);
+        y2milestone("Plugin service '%s' (%s) could not be refreshed, skipping it...",
+            alias.c_str(), serv_it->second.url().asString().c_str());
+        return true;
     }
 
     // load the service from disk

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -128,7 +128,8 @@ bool ServiceManager::RefreshService(const std::string &alias, zypp::RepoManager 
             repomgr.refreshService(serv_it->second);
         }
     }
-    // this is rather a notification from libzypp, not a real exception
+    // this is rather a notification from libzypp, not a real exception, see bsc#1086768 and
+    // https://github.com/openSUSE/libzypp/blob/921b2ababb4973b3c99a869529d279b803aab046/zypp/RepoManager.cc#L2090-L2093
     catch (const zypp::repo::ServicePluginInformalException& excpt)
     {
         y2milestone("Plugin service '%s' (%s) could not be refreshed, skipping it...",


### PR DESCRIPTION
- Avoid errors when refreshing the `zypp-plugin-spacewalk` service on a system not managed by spacewalk (SUSE Manager)
- Just ignore the `zypp::repo::ServicePluginInformalException` exception, do not fail in that case
- See [this comment in bugzilla](https://bugzilla.suse.com/show_bug.cgi?id=1086768#c13) by Michael Andres
- Libzypp actually misuses an exception for this instead of some notification callback, see [this comment in libzypp]( https://github.com/openSUSE/libzypp/blob/921b2ababb4973b3c99a869529d279b803aab046/zypp/RepoManager.cc#L2090-L2093)
- Tested manually with installed https://build.suse.de/package/show/SUSE:SLE-15:GA/zypp-plugin-spacewalk, no failure reported by YaST, excerpt from `y2log`:
  ```
  2018-05-16 18:04:05 <5> muffin(11633) [zypp] Exception.cc(log):166 ServiceRepos.cc(Plu
  ginServiceRepos):79 THROW:    [spacewalk|file:/usr/lib/zypp/plugins/services/spacewalk
  ] This system is not registered to any spacewalk server. If the system is not intended
  to be managed with spacewalk, please uninstall the zypp-plugin-spacewalk package.
  2018-05-16 18:04:05 <5> muffin(11633) [zypp] Exception.cc(log):166 
  2018-05-16 18:04:05 <1> muffin(11633) [Pkg] ServiceManager.cc(RefreshService):135 Plug
  in service 'spacewalk' (file:/usr/lib/zypp/plugins/services/spacewalk) could not be re
  freshed, skipping it...
  ```
- 4.0.10