### PR TITLE
Pkg.TargetInitializeOptions() - do not reset the source manager (bsc#1095702)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.10
+Version:        4.0.11
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jun  4 12:40:33 UTC 2018 - lslezak@suse.cz
+
+- Fixed Pkg.TargetInitializeOptions() to not reset the source
+  manager if also the options are the same as used previously
+  (bsc#1095702)
+- 4.0.11
+
+-------------------------------------------------------------------
 Wed May 16 16:07:27 UTC 2018 - lslezak@suse.cz
 
 - Ignore notification exception for failed plugin services,

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.10
+Version:        4.0.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -435,8 +435,8 @@ bool PkgFunctions::RepoManagerUpdateTarget(const std::string& root, const YCPMap
     bool new_target = _target_root != root;
 
     // a repository manager is present and the target has been changed
-    // or there are options to set
-    if ((repo_manager && new_target) || options.size() > 0)
+    // or the repo manager options changed
+    if ((repo_manager && new_target) || options.compare(repo_options) != YO_EQUAL)
     {
         y2milestone("Updating RepoManager (target changed from %s to %s)", _target_root.c_str(), root.c_str());
 
@@ -470,6 +470,9 @@ bool PkgFunctions::RepoManagerUpdateTarget(const std::string& root, const YCPMap
         // replace the old repository manager
         if (repo_manager) delete repo_manager;
         repo_manager = new_repo_manager;
+
+        // remember the repo options for the next time
+        repo_options = options;
     }
 
     // update package cache path for loaded repositories when changing the target

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -240,6 +240,8 @@ class PkgFunctions
 
       std::vector<zypp::filesystem::TmpDir> tmp_dirs;
 
+      YCPMap repo_options;
+
       /**
        * Logging helper:
        * search for a repository and in case of exception, log error


### PR DESCRIPTION
- Fir for https://bugzilla.suse.com/show_bug.cgi?id=1095702 which appeared after changing `Pkg.TargetInitialize(destdir)` call to `Pkg.TargetInitializeOptions(destdir, "target_distro" => distro)` to set the  option properly (https://github.com/yast/yast-registration/pull/374/files#diff-7e065d2a9d63b84d4b6c60bbd39314dbR629)
- The original condition was wrong, it reset the repo manager when the options were not empty
- If the same options are used as previously with the same target then we do not need to reload the sources. Reloading can loose some information.
- Unfortunately not tested as I could not reproduce the issue on x86_64, I guess the problem on S390 is related to only one product available. Let's delegate the testing to openQA...
- 4.0.11