### PR TITLE
Do not save plugin service to the target system (bsc#1094468)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.11
+Version:        4.0.12
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 19 13:12:21 UTC 2018 - lslezak@suse.cz
+
+- Do not save plugin service to the target system, it is defined
+  by a script (bsc#1094468)
+- 4.0.12
+
+-------------------------------------------------------------------
 Mon Jun  4 12:40:33 UTC 2018 - lslezak@suse.cz
 
 - Fixed Pkg.TargetInitializeOptions() to not reset the source

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.11
+Version:        4.0.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -324,7 +324,7 @@ void ServiceManager::SavePkgService(PkgService &s_known, zypp::RepoManager &repo
 
     // plugin services cannot be saved, they are provided by a script
     // https://doc.opensuse.org/projects/libzypp/SLE12SP1/zypp-services.html
-    if (s_stored.type() == zypp::repo::ServiceType::PLUGIN)
+    if (s_known.type() == zypp::repo::ServiceType::PLUGIN)
     {
         y2milestone("Not saving a plugin service: %s", orig_alias.c_str());
         return;


### PR DESCRIPTION
- YaST by mistake saved a `*.service` file for a zypp plugin service, but plugin services do not need a `*.service` file. The scripts (plugins) are directly read from `/usr/lib/zypp/plugins/services/`.
- See https://bugzilla.suse.com/show_bug.cgi?id=1094468

As showed in the log, the stored service was empty (actually a null object `zypp::ServiceInfo::noService`):

```
ServiceManager.cc(SavePkgService):333 Known Service: [spacewalk]
ServiceManager.cc(SavePkgService):333 enabled=1
ServiceManager.cc(SavePkgService):333 autorefresh=1
ServiceManager.cc(SavePkgService):333 url = file:/mnt/usr/lib/zypp/plugins/services/spacewalk
ServiceManager.cc(SavePkgService):333 type = plugin
ServiceManager.cc(SavePkgService):333
ServiceManager.cc(SavePkgService):334 Stored Service: []
ServiceManager.cc(SavePkgService):334 enabled=1
ServiceManager.cc(SavePkgService):334 autorefresh=0
ServiceManager.cc(SavePkgService):334 url =
ServiceManager.cc(SavePkgService):334 type = NONE
ServiceManager.cc(SavePkgService):334
ServiceManager.cc(SavePkgService):341 Adding new service spacewalk
```

In this case the service plugin has been removed from the system during upgrade so the target service is not present anymore at the end:

```
clients/packages_proposal.rb:89 Removed packages: ["3ddiag",...,"zypp-plugin-spacewalk"]
```

So instead of checking the type of the `s_stored` variable (from the system) we need to check the type of the `s_known` variable (the loaded service remembered by pkg-bindings).