### PR TITLE
Fix expanding URL

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.0.13
+Version:        4.1.0
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 31 11:41:54 UTC 2018 - jreidinger@suse.com
+
+- Fix probing repository with URL including variable (bsc#1090193)
+- 4.1.0
+
+-------------------------------------------------------------------
 Mon Oct 29 16:53:20 UTC 2018 - jreidinger@suse.com
 
 - Drop no longer used methods:

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.0.13
+Version:        4.1.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -757,7 +757,7 @@ PkgFunctions::SourceCreateEx (const YCPString& media, const YCPString& pd, bool 
       {
 	    ids->add(YCPInteger(*it));
       }
-    
+
       return ids;
   }
 }
@@ -776,7 +776,7 @@ YCPValue PkgFunctions::RepositoryProbe(const YCPString& url, const YCPString& pr
 
     try
     {
-	zypp::Url probe_url(url->value());
+	zypp::Url probe_url(ExpandedUrl(url)->asString()->value());
 	y2milestone("Probing repository type: '%s'...", probe_url.asString().c_str());
 
 	// add the product directory


### PR DESCRIPTION
- [x] keep variable on target system

https://trello.com/c/C9qg20xz/411-ludwigs-favorite-2-sle-15-sp1-handle-val-well-when-adding-a-repository

Tested manually in installation same way as failed openQA job did and also verify on target system, that it is stored with variable and all operation like zypper ref works.

