### PR TITLE
Drop the cached source manager (bsc#1120568)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 10 08:23:27 UTC 2019 - lslezak@suse.cz
+
+- SourceFinishAll: drop the cached source manager to reload the
+  repositories from disk, avoid restoring the removed repositories
+  (bsc#1120568)
+- 4.1.1
+
+-------------------------------------------------------------------
 Wed Oct 31 11:41:54 UTC 2018 - jreidinger@suse.com
 
 - Fix probing repository with URL including variable (bsc#1090193)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Source_Save.cc
+++ b/src/Source_Save.cc
@@ -277,6 +277,13 @@ PkgFunctions::SourceFinishAll ()
 
 	// release all services
 	service_manager.Reset();
+
+	if (repo_manager)
+	{
+		y2milestone("Releasing the repo manager...");
+		delete repo_manager;
+		repo_manager = nullptr;
+	}
     }
     catch (zypp::Exception & excpt)
     {
@@ -286,13 +293,6 @@ PkgFunctions::SourceFinishAll ()
     }
 
     y2milestone("All sources and services have been unregistered");
-
-    if (repo_manager)
-    {
-      y2milestone("Releasing the repo manager...");
-      delete repo_manager;
-      repo_manager = nullptr;
-    }
 
     return YCPBoolean(true);
 }

--- a/src/Source_Save.cc
+++ b/src/Source_Save.cc
@@ -287,6 +287,13 @@ PkgFunctions::SourceFinishAll ()
 
     y2milestone("All sources and services have been unregistered");
 
+    if (repo_manager)
+    {
+      y2milestone("Releasing the repo manager...");
+      delete repo_manager;
+      repo_manager = nullptr;
+    }
+
     return YCPBoolean(true);
 }
 


### PR DESCRIPTION
- Related to bug https://bugzilla.suse.com/show_bug.cgi?id=1120568.
- Drop the source manager to force reloading the repositories from disk, avoid restoring the removed repositories.
- The source manager is lazily created and cached [here](https://github.com/yast/yast-pkg-bindings/blob/78f5ce710aa8973f50227150ed570467d0d71885/src/PkgFunctions.cc#L220-L230).
- 4.1.1

## Bug

``` ruby
Yast::Pkg.TargetInit("/", true)
# load the repositories from system, there are 10 repos:
Yast::Pkg.SourceStartCache(false) # => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
# unload all repositories
Yast::Pkg.SourceFinishAll
# just verify that no repo has been left
Yast::Pkg.SourceGetCurrent(false) # => []
# remove the repository files from disk (do not try this at home!)
system "rm -rf /etc/zypp/repos.d/*"
# load the repositories from disk again,
# it returns the removed repositories!!
Yast::Pkg.SourceStartCache(false) # => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```

## Fixed Version

``` ruby
# (start with the same steps as above)

system "rm -rf /etc/zypp/repos.d/*"
# load the repositories from disk again,
# nothing found as expected
Yast::Pkg.SourceStartCache(false) # => []
```

