### PR TITLE
Fixed Pkg.Resolvables() to properly filter by status

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 13 15:03:30 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed Pkg.Resolvables() to properly filter by status
+  (related to bsc#1132650)
+- 4.2.2
+
+-------------------------------------------------------------------
 Tue Oct 29 12:39:09 CET 2019 - schubi@suse.de
 
 - Returning raw packages dependencies while calling

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -925,7 +925,7 @@ struct ResolvableFilter
 			}
 			else if (status_str == "available")
 			{
-				if (!status.staysUninstalled()) return false;
+				if (!(status.staysUninstalled() || !status.isSatisfied())) return false;
 			}
 			else if (status_str == "removed")
 			{


### PR DESCRIPTION
- The `status.isInstalled()` condition is `true` also for products which are selected to uninstall, the right call for the installed and not removed resolvables is `status.staysInstalled()`.
- Updated the smoke test
- Tested manually
- 4.2.2

### Original Behavior

```
(byebug) Yast::Pkg.Resolvables({kind: :product, status: :installed}, [:status])
[{"product_package"=>"sles-release", "status"=>:removed}, {"product_package"=>
"sle-module-basesystem-release", "status"=>:installed}, {"product_package"=>
"sle-module-server-applications-release", "status"=>:installed}, {"product_package"=>
"sle-module-desktop-applications-release", "status"=>:installed}, {"product_package"=>
"sle-module-development-tools-release", "status"=>:installed}]
```

As  you can see the result wrongly contains also the removed product, not only the installed products as requested. Moreover the `product_package` attribute was also returned while we asked only for the status.

### Fixed Version

```
(byebug) Yast::Pkg.Resolvables({kind: :product, status: :installed}, [:status])
[{"status"=>:installed}, {"status"=>:installed}, {"status"=>:installed},
{"status"=>:installed}]
```

The result correctly contains only the installed products and the `product_package` attribute is not added there anymore.