### PR TITLE
Fixed Pkg.Resolvables() (bsc#1158247)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec  3 09:18:14 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed Pkg.Resolvables() to return the license text when requested
+  (bsc#1158247)
+- 4.2.3
+
+-------------------------------------------------------------------
 Wed Nov 13 15:03:30 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed Pkg.Resolvables() to properly filter by status

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -285,6 +285,9 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
     if ((all && !license.empty()) || attrs->contains(YCPSymbol("license_confirmed")))
 	{
 		info->add(YCPString("license_confirmed"), YCPBoolean(item.status().isLicenceConfirmed()));
+	}
+    if ((all && !license.empty()) || attrs->contains(YCPSymbol("license")))
+	{
 		info->add(YCPString("license"), YCPString(license));
 	}
 


### PR DESCRIPTION
- Fixed `Pkg.Resolvables()` to return the license text when requested
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1158247
- Tested manually
- 4.2.3