### PR TITLE
Export the list of dependencies even when it is empty

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 12 15:52:08 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Include the "deps" resolvable property even when it is empty
+  (bsc#1159120).
+- 4.2.4
+
+-------------------------------------------------------------------
 Tue Dec  3 09:18:14 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed Pkg.Resolvables() to return the license text when requested

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -568,10 +568,10 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
             }
 		}
 
-		if (ycpdeps.size() > 0)
+		if (ycpdeps.size() > 0 || attrs->contains(YCPSymbol("dependencies")))
 			info->add (YCPString ("dependencies"), ycpdeps);
 
-		if (rawdeps.size() > 0)
+		if (rawdeps.size() > 0 || attrs->contains(YCPSymbol("deps")))
 			info->add (YCPString ("deps"), rawdeps);
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/yast/yast-yast2/pull/998 which implements [@lslezak's the suggestion](https://github.com/yast/yast-yast2/pull/998#issuecomment-565055968).