### PR TITLE
Fix calculation of replaced products in Pkg.Resolvable2YCPMap()

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.2.6
+Version:        3.2.7
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 13 12:18:43 UTC 2020 - Petr Pavlu <petr.pavlu@suse.com>
+
+- Fix calculation of replaced products in Pkg.Resolvable2YCPMap()
+  (bsc#1157202)
+- 3.2.7
+
+-------------------------------------------------------------------
 Mon Oct 14 13:16:39 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added Pkg.Resolvables() and Pkg.AnyResolvable() calls as

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.2.6
+Version:        3.2.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -401,13 +401,17 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
 				rprod->add(YCPString("description"), YCPString(replacedProduct->description()));
 
 				std::string product_summary = replacedProduct->summary();
-				ADD_NOT_EMPTY_STRING("display_name", product_summary);
+				if (!product_summary.empty())
+					rprod->add(YCPString("display_name"), YCPString(product_summary));
 
 				std::string product_shortname = replacedProduct->shortName();
-				ADD_NOT_EMPTY_STRING("short_name", product_shortname)
+				if (!product_shortname.empty())
+					rprod->add(YCPString("short_name"), YCPString(product_shortname));
 				// use summary for the short name if it's defined
-				else if (product_summary.size() > 0)
+				else if (!product_summary.empty())
 					rprod->add(YCPString("short_name"), YCPString(product_summary));
+
+				rep_prods->add(rprod);
 			}
 
 			info->add(YCPString("replaces"), rep_prods);


### PR DESCRIPTION
* Record "display_name" and "short_name" properly under each replaced product, instead of overwriting values for the main queried product.
* Fix adding of replaced products to the "replaced" list.

Fixes bsc#1157202.