### PR TITLE
Replaced product details

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 13 12:18:43 UTC 2020 - Petr Pavlu <petr.pavlu@suse.com>
+
+- Fix calculation of replaced products in Pkg.Resolvable2YCPMap()
+  (bsc#1157202)
+- 4.2.5
+
+-------------------------------------------------------------------
 Thu Dec 12 15:52:08 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Include the "deps" resolvable property even when it is empty

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -406,13 +406,17 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
 				rprod->add(YCPString("description"), YCPString(replacedProduct->description()));
 
 				std::string product_summary = replacedProduct->summary();
-				ADD_NOT_EMPTY_STRING("display_name", product_summary);
+				if (!product_summary.empty())
+					rprod->add(YCPString("display_name"), YCPString(product_summary));
 
 				std::string product_shortname = replacedProduct->shortName();
-				ADD_NOT_EMPTY_STRING("short_name", product_shortname)
+				if (!product_shortname.empty())
+					rprod->add(YCPString("short_name"), YCPString(product_shortname));
 				// use summary for the short name if it's defined
-				else if (product_summary.size() > 0)
+				else if (!product_summary.empty())
 					rprod->add(YCPString("short_name"), YCPString(product_summary));
+
+				rep_prods->add(rprod);
 			}
 
 			info->add(YCPString("replaces"), rep_prods);


### PR DESCRIPTION
- Just merging #122 from SLE12-SP5 to `master`
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1157202
- Fixes evaluating replaced products in the `ResolvableProperties` call
  - The `ADD_NOT_EMPTY_STRING` macro adds the value to the resulting `YCPHash`, but we need to add it into the sublist (`rprod`).
  - Moreover the `rprod` was actually not added to the result at all...
