### PR TITLE
SLE12-SP5 backports

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        3.2.7
+Version:        3.2.8
 Release:        0
 License:        GPL-2.0
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Thu Jan 16 08:29:24 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Backported some more Pkg.Resolvables() fixes from SLE15-SP2:
+  - Include the "deps" resolvable property even when it is empty
+    (bsc#1159120)
+  - Fixed Pkg.Resolvables() to return the license text when requested
+    (bsc#1158247)
+  - Fixed Pkg.Resolvables() to properly filter by status
+    (related to bsc#1132650)
+  - Returning raw packages dependencies while calling
+    <Y2Packager::Resolvable>.deps (bsc#1132650)
+- 3.2.8
+
+-------------------------------------------------------------------
 Mon Jan 13 12:18:43 UTC 2020 - Petr Pavlu <petr.pavlu@suse.com>
 
 - Fix calculation of replaced products in Pkg.Resolvable2YCPMap()

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        3.2.7
+Version:        3.2.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- When porting the https://bugzilla.suse.com/show_bug.cgi?id=1157202 fix (PR #122) to master I found out that many other fixes are missing in SLE12-SP5.
- To avoid future bug reports we should backport them.
- I just copied the whole `src/Resolvable_Properties.cc` file from `master` to avoid mistakes or miss some fix.