### PR TITLE
Source restore

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Feb 20 17:02:03 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed obsolete zypp::target::rpm::ConvertDBReport callbacks,
+  not used since SLE12 (by mlandres)
+- Fixed Pkg.SourceRestore call to allow reading the stored
+  repositories even after the initial installation repository has
+  been added (bsc#1163081)
+- 4.2.6
+
+-------------------------------------------------------------------
 Mon Jan 13 12:18:43 UTC 2020 - Petr Pavlu <petr.pavlu@suse.com>
 
 - Fix calculation of replaced products in Pkg.Resolvable2YCPMap()

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -61,6 +61,7 @@ const zypp::ResStatus::TransactByValue PkgFunctions::whoWantsIt = zypp::ResStatu
 PkgFunctions::PkgFunctions () :
       _target_root( "/" )
     , _target_loaded(false)
+    , _source_loaded(false)
     , zypp_pointer(NULL)
     , repo_manager(NULL)
     , autorefresh_skipped(false)

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -83,6 +83,7 @@ class PkgFunctions
 
 	zypp::Pathname _target_root;
 	bool _target_loaded;
+	bool _source_loaded;
 
 	zypp::ZYpp::Ptr zypp_pointer;
 

--- a/src/Source_Load.cc
+++ b/src/Source_Load.cc
@@ -55,9 +55,9 @@ PkgFunctions::SourceRestore()
     // return value
     bool success = true;
 
-    if (repos.size() > 0)
+    if (_source_loaded)
     {
-	y2warning("Number of registered repositories: %zd, skipping repository load!", repos.size());
+	y2warning("Repositories already loaded, skipping repository load!");
 	return YCPBoolean(success);
     }
 
@@ -112,6 +112,7 @@ PkgFunctions::SourceRestore()
 			}
 		    }
 		}
+				_source_loaded = true;
 	    }
 	    catch (const zypp::Exception& excpt)
 	    {

--- a/src/Source_Load.cc
+++ b/src/Source_Load.cc
@@ -112,7 +112,7 @@ PkgFunctions::SourceRestore()
 			}
 		    }
 		}
-				_source_loaded = true;
+		_source_loaded = true;
 	    }
 	    catch (const zypp::Exception& excpt)
 	    {

--- a/src/Source_Save.cc
+++ b/src/Source_Save.cc
@@ -293,8 +293,8 @@ PkgFunctions::SourceFinishAll ()
     }
 
     y2milestone("All sources and services have been unregistered");
-		// reset the source loaded flag
-		_source_loaded = false;
+    // reset the source loaded flag
+    _source_loaded = false;
 
     return YCPBoolean(true);
 }

--- a/src/Source_Save.cc
+++ b/src/Source_Save.cc
@@ -293,6 +293,8 @@ PkgFunctions::SourceFinishAll ()
     }
 
     y2milestone("All sources and services have been unregistered");
+		// reset the source loaded flag
+		_source_loaded = false;
 
     return YCPBoolean(true);
 }


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1163081
- We need to ensure that the `Pkg.SourceRestore` call is called only once in the installation workflow (restoring the original repositories after going back would loose all changes). The original implementation checked whether there was at least one repository present, but if it is the initial installation repository then it's still safe to load the repositories from the system. So let's have a flag for that, similar to the target loaded flag.
- Tested manually (with https://github.com/yast/yast-update/pull/151)