### PR TITLE
handle raw repository name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
   # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
   # run additional smoke tests to check the basic functionality
-  - docker run -it yast-pkg-bindings-image bash -c "yast-travis-cpp && ./smoke_test_prepare.sh && ./smoke_test_run.rb"
+  - docker run -it --privileged yast-pkg-bindings-image bash -c "yast-travis-cpp && ./smoke_test_prepare.sh && ./smoke_test_run.rb"
 
 after_success:
   - ./.surge.sh

--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 10 09:24:53 CEST 2020 - aschnell@suse.com
+
+- Extensions to handle raw repository name (bsc#1172477)
+- 4.2.8
+
+-------------------------------------------------------------------
 Wed Feb 26 08:50:50 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix SourceRestore when some service is defined (bsc#1163081)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -52,7 +52,6 @@ echo "src" > SUBDIRS
 %yast_install
 
 rm -rf %{buildroot}/%{yast_plugindir}/libpy2Pkg.la
-
 
 %files
 %defattr(-,root,root)

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -79,6 +79,15 @@ raise "Pkg.ResolvableProperties failed!" unless packages
 raise "No package found!" if packages.empty?
 puts "OK (found #{packages.size} packages)"
 
+# make sure a name without variables stays the same
+puts "Checking Pkg.ExpandedName..."
+name = "YaST"
+expanded_name = Yast::Pkg.ExpandedName(name)
+if name != expanded_name
+  raise "Unexpected result: #{expanded_name.inspect}, expected #{name.inspect}"
+end
+puts "OK"
+
 # make sure no URL part is lost by Pkg.ExpandedUrl call (bsc#1067007)
 puts "Checking Pkg.ExpandedUrl..."
 url = "https://user:pwd@example.com/path?opt=value"

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -19,7 +19,6 @@
  */
 
 /*
-   File:	$Id$
    Author:	Ladislav Slezák <lslezak@novell.com>
    Summary:     Functions related to error handling
    Namespace:   Pkg
@@ -507,6 +506,22 @@ bool PkgFunctions::SetTarget(const std::string &root, const YCPMap& options)
     return new_target;
 }
 
+
+YCPValue
+PkgFunctions::ExpandedName(const YCPString& name) const
+{
+    if (name.isNull())
+    {
+	y2error("name is nil");
+	return YCPVoid();
+    }
+
+    zypp::RepoVariablesReplacedString replaced_name;
+    replaced_name.raw() = name->value();
+    return YCPString(replaced_name.transformed());
+}
+
+
 /**
  * @builtin ExpandedUrl
  * @short expands the repo variables in the given zypper URL
@@ -521,10 +536,11 @@ YCPValue PkgFunctions::ExpandedUrl(const YCPString &url)
     }
 
     zypp::RepoVariablesReplacedUrl replacedUrl;
-    replacedUrl.raw() = zypp::Url(url->asString()->value());
+    replacedUrl.raw() = zypp::Url(url->value());
     // return full URL including the password if present
     return YCPString(replacedUrl.transformed().asCompleteString());
 }
+
 
 /**
  * @builtin CompareVersions

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -19,7 +19,6 @@
  */
 
 /*
-   File:	$Id$
    Author:	Ladislav Slezák <lslezak@novell.com>
    Summary:     Handles Pkg::function (list_of_arguments) calls
    Namespace:   Pkg
@@ -303,6 +302,8 @@ class PkgFunctions
 	YCPValue LastErrorDetails ();
 	/* TYPEINFO: boolean() */
 	YCPValue Connect ();
+	/* TYPEINFO: string(string)*/
+	YCPValue ExpandedName(const YCPString&) const;
 	/* TYPEINFO: string(string)*/
 	YCPValue ExpandedUrl (const YCPString&);
 

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -19,7 +19,6 @@
  */
 
 /*
-   File:	$Id$
    Author:	Ladislav Slezák <lslezak@novell.com>
    Summary:     Functions related to repository registration
    Namespace:   Pkg
@@ -320,8 +319,8 @@ PkgFunctions::createManagedSource( const zypp::Url & url_r,
  * metadata is not downloaded, use Pkg::SourceRefreshNow() for that. The metadata is also loaded
  * automatically when loading the repository content (Pkg::SourceLoad())
  *
- * @param map map with repository parameters: $[ "enabled" : boolean, "autorefresh" : boolean, "name" : string,
- *   "alias" : string, "base_urls" : list<string>, "check_alias" : boolean, "priority" : integer, "prod_dir" : string, "type" : string ] 
+ * @param map map with repository parameters: $[ "enabled" : boolean, "autorefresh" : boolean, "raw_name" : string, "name" : string,
+ *   "alias" : string, "base_urls" : list<string>, "check_alias" : boolean, "priority" : integer, "prod_dir" : string, "type" : string ]
  * @return integer Repository ID or nil on error
  **/
 YCPValue PkgFunctions::RepositoryAdd(const YCPMap &params)
@@ -443,8 +442,12 @@ YCPValue PkgFunctions::RepositoryAdd(const YCPMap &params)
     repo.setAlias(alias);
 
 
-    // check name parameter
-    if (!params->value( YCPString("name") ).isNull() && params->value(YCPString("name"))->isString())
+    // check raw_name and name parameter
+    if (!params->value( YCPString("raw_name") ).isNull() && params->value(YCPString("raw_name"))->isString())
+    {
+	repo.setName(params->value(YCPString("raw_name"))->asString()->value());
+    }
+    else if (!params->value( YCPString("name") ).isNull() && params->value(YCPString("name"))->isString())
     {
 	repo.setName(params->value(YCPString("name"))->asString()->value());
     }
@@ -500,6 +503,7 @@ YCPValue PkgFunctions::RepositoryAdd(const YCPMap &params)
     // the new source is at the end of the list
     return YCPInteger(repos.size() - 1);
 }
+
 
 /**
  * @builtin SourceCreate

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -19,7 +19,6 @@
  */
 
 /*
-   File:	$Id$
    Author:	Ladislav Slezák <lslezak@novell.com>
    Summary:     Functions for reading repository properties
    Namespace:   Pkg
@@ -113,6 +112,7 @@ PkgFunctions::SourceGetCurrent (const YCPBoolean& enabled)
  * "raw_url"	: YCPString (without password, but see SourceRawURL, raw URL without variable replacement),
  * "alias"	: YCPString,
  * "name"	: YCPString,
+ * "raw_name"	: YCPString (raw name without variable replacement),
  * "service"	: YCPString, (service to which the repo belongs, empty if there is no service assigned)
  * "keeppackages" : YCPBoolean,
  * "is_update_repo" : YCPBoolean, (true if this is an update repo - this requires loaded objects in pool otherwise the flag is not returned! The value is stored in repo metadata, not in .repo file!)
@@ -148,7 +148,9 @@ PkgFunctions::SourceGeneralData (const YCPInteger& id)
     }
 
     data->add( YCPString("alias"),		YCPString(repo->repoInfo().alias()));
+
     data->add( YCPString("name"),		YCPString(repo->repoInfo().name()));
+    data->add( YCPString("raw_name"),		YCPString(repo->repoInfo().rawName()));
 
     YCPList base_urls;
     for( zypp::RepoInfo::urls_const_iterator it = repo->repoInfo().baseUrlsBegin(); it != repo->repoInfo().baseUrlsEnd(); ++it)
@@ -400,6 +402,7 @@ PkgFunctions::SourceProductData (const YCPInteger& src_id)
  * "enabled"	: YCPBoolean,
  * "autorefresh": YCPBoolean,
  * "name"	: YCPString,
+ * "raw_name"	: YCPString,
  * "service"	: YCPString,
  * "keeppackages" : YCPBoolean,
  * ];
@@ -424,6 +427,7 @@ PkgFunctions::SourceEditGet ()
 	    // Note: autorefresh() is tribool
 	    src_map->add(YCPString("autorefresh"), YCPBoolean((*it)->repoInfo().autorefresh()));
 	    src_map->add(YCPString("name"), YCPString((*it)->repoInfo().name()));
+	    src_map->add(YCPString("raw_name"), YCPString((*it)->repoInfo().rawName()));
 	    src_map->add(YCPString("priority"), YCPInteger((*it)->repoInfo().priority()));
 	    src_map->add(YCPString("service"), YCPString((*it)->repoInfo().service()));
 	    src_map->add(YCPString("keeppackages"), YCPBoolean((*it)->repoInfo().keepPackages()));

--- a/src/Source_Set.cc
+++ b/src/Source_Set.cc
@@ -19,7 +19,6 @@
  */
 
 /*
-   File:	$Id$
    Author:	Ladislav Slezák <lslezak@novell.com>
    Summary:     Functions for changing properties of a repository 
    Namespace:   Pkg
@@ -226,11 +225,19 @@ PkgFunctions::SourceEditSet (const YCPList& states)
 	repo->repoInfo().setAutorefresh( autorefresh );
     }
 
-    if( !descr->value(YCPString("name")).isNull() && descr->value(YCPString("name"))->isString())
+    if( !descr->value(YCPString("raw_name")).isNull() && descr->value(YCPString("raw_name"))->isString())
     {
 	// rename the source
-        y2debug("set name: %s", descr->value(YCPString("name"))->asString()->value().c_str());
-	repo->repoInfo().setName(descr->value(YCPString("name"))->asString()->value());
+	string raw_name = descr->value(YCPString("raw_name"))->asString()->value();
+	y2debug("set name: %s", raw_name.c_str());
+	repo->repoInfo().setName(raw_name);
+    }
+    else if( !descr->value(YCPString("name")).isNull() && descr->value(YCPString("name"))->isString())
+    {
+	// rename the source
+	string name = descr->value(YCPString("name"))->asString()->value();
+	y2debug("set name: %s", name.c_str());
+	repo->repoInfo().setName(name);
     }
 
     if( !descr->value(YCPString("priority")).isNull() && descr->value(YCPString("priority"))->isInteger())
@@ -238,8 +245,8 @@ PkgFunctions::SourceEditSet (const YCPList& states)
 	unsigned int priority = descr->value(YCPString("priority"))->asInteger()->value();
 
 	// set the priority
-	repo->repoInfo().setPriority(priority);
 	y2debug("set priority: %d", priority);
+	repo->repoInfo().setPriority(priority);
     }
 
     if(!descr->value(YCPString("keeppackages")).isNull() && descr->value(YCPString("keeppackages"))->isBoolean())
@@ -423,5 +430,3 @@ PkgFunctions::SourceDelete (const YCPInteger& id)
 
     return YCPBoolean(success);
 }
-
-


### PR DESCRIPTION
This PR extends the pkg-bindings to allow working with the raw repository name. It is done is a way that existing code continues to work: When setting the name, the "raw_name" is preferred over the "name".

For https://trello.com/c/QAAv9cMG/1895-3-osdistribution-p2-1172477-yast-replaces-releasever-by-the-current-release-in-repository-names-in-etc-zypp-reposd-repo and https://bugzilla.suse.com/show_bug.cgi?id=1172477.
