### PR TITLE
Fixed saving service files (bsc#1171977)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 17 07:23:30 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed migration from SLE-HPC-12 with activated HPC module to
+  SLE15-SP2 (fixed saving service files) (bsc#1171977)
+- 4.2.9
+
+-------------------------------------------------------------------
 Fri Jul 10 09:24:53 CEST 2020 - aschnell@suse.com
 
 - Extensions to handle raw repository name (bsc#1172477)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -341,7 +341,7 @@ void ServiceManager::SavePkgService(PkgService &s_known, zypp::RepoManager &repo
     if (s_stored == zypp::ServiceInfo::noService)
     {
         // remove the file if it already exists
-        // (a corner case, the libzypp loaded is data out of sync with the disk content)
+        // (a corner case, the libzypp data is out of sync with the disk content)
         if (zypp::PathInfo(file_path).isExist())
         {
             MIL << "removing file " << file_path << std::endl;
@@ -357,7 +357,7 @@ void ServiceManager::SavePkgService(PkgService &s_known, zypp::RepoManager &repo
     else
     {
         // create the file if it is missing
-        // (a corner case, the libzypp loaded is data out of sync with the disk content)
+        // (a corner case, the libzypp data is out of sync with the disk content)
         if (!zypp::PathInfo(file_path).isExist())
         {
             MIL << "creating file " << file_path << std::endl;


### PR DESCRIPTION
## Description

- Fixed migration from SLE-HPC-12 with activated HPC module to SLE15-SP2
- See https://bugzilla.suse.com/show_bug.cgi?id=1171977

## Details

- We already had a similar bug in the past when migrating via SMT: https://bugzilla.suse.com/show_bug.cgi?id=1097756, fixed in #104 
- It may happen that the libzypp data in memory do not match the status on disk. In some rare cases the old service file might still exist when adding a new service. Or the other way round, the old service file might have been deleted, but the new service re-uses the same name so for libzypp it is modification of existing service.
- This fix ensures that when adding a new service the service file is not there (it is deleted) or when modifying a service the service file already exists.

## Testing

- I have verified that the fix works in the reported scenario (migration via RMT)
- To avoid regressions I also tested a migration via SCC (was OK)
- I wanted also to try a migration via SMT, but I got some strange error messages from both `smt.suse.de` and `smt.suse.cz`, I guess they are not configured for this migrations. I'll ask the QA team to verify all supported scenarios.