### PR TITLE
[bsc#1175317] Allow filtering by RPM dependencies in Pkg::Resolvables() call

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.9
+Version:        4.3.0
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 24 11:53:42 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improved Pkg::Resolvables() call to allow filtering by RPM
+  dependencies (provides, obsoletes,...) (related to bsc#1175317)
+- 4.3.0
+
+-------------------------------------------------------------------
 Wed Jul 22 16:02:16 CEST 2020 - aschnell@suse.com
 
 - Expand URL when libzypp expects an expanded URL. Fixes weird zypp

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.9
+Version:        4.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/smoke_test_prepare.sh
+++ b/smoke_test_prepare.sh
@@ -10,3 +10,7 @@ rpm -iv --force --nodeps /usr/src/packages/RPMS/*/*.rpm
 
 # clear the log if present, it will be checked later
 rm -f /var/log/YaST2/y2log
+
+# disable the OSS repository, it contains over 60k packages and that slows down
+# some Pkg tests a lot
+zypper mr -d repo-oss

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -107,7 +107,7 @@ end
 puts "OK"
 
 # Check all packages - this expects at least one package is available/installed
-puts "Checking Pkg.Resolvabless..."
+puts "Checking Pkg.Resolvables..."
 resolvables = Yast::Pkg.Resolvables({kind: :package}, [])
 raise "Pkg.Resolvables failed!" unless resolvables
 raise "No package found!" if resolvables.empty?
@@ -129,6 +129,18 @@ puts "OK (yast2-core package installed)"
 selected_packages = Yast::Pkg.Resolvables({kind: :package, status: :selected}, [:name])
 raise "A package is selected to install (???)" unless selected_packages.empty?
 puts "OK (no package selected)"
+
+obsolete_packages = Yast::Pkg.Resolvables({kind: :package, obsoletes_regexp: "^yast2-config-"}, [])
+raise "No package with yast2-config obsoletes found" if obsolete_packages.empty?
+puts "OK (found #{obsolete_packages.size} packages with yast2-config-* obsoletes)"
+
+supplement_packages = Yast::Pkg.Resolvables({kind: :package, supplements_regexp: "^autoyast\\(.*\\)"}, [])
+raise "No package with autoyast() supplements found" if supplement_packages.empty?
+puts "OK (found #{supplement_packages.size} packages with autoyast() supplements)"
+
+provide_packages = Yast::Pkg.Resolvables({kind: :package, provides: "y2c_online_update"}, [])
+raise "No package with y2c_online_update provides found" if provide_packages.empty?
+puts "OK (found #{provide_packages.size} packages providing y2c_online_update)"
 
 removed = Yast::Pkg.ResolvableRemove("yast2-core", :package)
 raise "Cannot select yast2-core to uninstall" unless removed

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -80,8 +80,14 @@ namespace zypp {
 // ------------------------
 /**
  *  @builtin PkgQueryProvides
- *  @short List all package instances providing 'tag'
+ *  @short [OBSOLETE] List all package instances providing 'tag'
  *  @description
+ *
+ *  **Obsolete**
+ *
+ *  This call is obsolete, use `Resolvables()` call instead, it can
+ *  use also the other RPM dependencies and allows using regexps.
+ *
  *  A package instance is itself a list of three items:
  *
  *  - string name: The package name
@@ -114,6 +120,9 @@ namespace zypp {
 YCPList
 PkgFunctions::PkgQueryProvides( const YCPString& tag )
 {
+	y2warning("Pkg::PkgQueryProvides() is obsolete.");
+	y2warning("Use Pkg::Resolvables({provides: ...}, [...]) instead.");
+
     YCPList ret;
     std::string name = tag->value();
 

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -1072,10 +1072,11 @@ private:
 
 /**
    @builtin Resolvables
-   @short Is there any resolvable matching the input filter?
+   @short Return resolvables matching the input filter, if the regexp is invalid
+	   (for example by confusing it with a shell pattern), nil is returned.
    @param map filter
    @param list attrs the list of required attributes
-   @return boolean true if a resolvable was found, false otherwise, nil
+   @return list list of found resolvables (maps), nil
 	   if an error occurred (call Pkg.LastError() to get the details)
 
    See the ResolvableProperties() call for the accepted filtering keys
@@ -1120,7 +1121,8 @@ YCPValue PkgFunctions::Resolvables(const YCPMap& filter, const YCPList& attrs)
 
 /**
    @builtin AnyResolvable
-   @short Is there any resolvable matching the input filter?
+   @short Is there any resolvable matching the input filter? If the regexp is invalid
+	   (for example by confusing it with a shell pattern), nil is returned.
    @param map filter
    @return boolean true if a resolvable was found, false otherwise, nil
 	   if an error occurred (call Pkg.LastError() to get the details)

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -1095,7 +1095,7 @@ private:
 		 obsoletes_regexp: "^yast2-config-"
 		 supplements_regexp: "^autoyast\\(.*\\)"
 
-	 You can pass several depency filters, in that case the result is logical AND,
+	 You can pass several dependency filters, in that case the result is logical AND,
 	 i.e. all required dependency filters must match.
 */
 YCPValue PkgFunctions::Resolvables(const YCPMap& filter, const YCPList& attrs)

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -29,6 +29,8 @@
 #include "log.h"
 #include "ycpTools.h"
 
+#include <set>
+
 #include <ycp/YCPBoolean.h>
 #include <ycp/YCPInteger.h>
 #include <ycp/YCPSymbol.h>
@@ -48,6 +50,7 @@
 #include <zypp/sat/LocaleSupport.h>
 #include <zypp/parser/ProductFileReader.h>
 #include <zypp/base/Regex.h>
+#include <zypp/PoolQuery.h>
 
 /**
    @builtin ResolvableProperties
@@ -806,7 +809,15 @@ struct ResolvableFilter
 	ResolvableFilter(const YCPMap &attributes, const PkgFunctions &pf)
 		: pkg(pf), check_repo(false), check_transact_by(false), check_vendor(false),
 		check_locked(false), check_on_system(false), check_license_confirmed(false),
-		medium_nr(-1)
+		medium_nr(-1),
+		check_provides(false), check_regexp_provides(false),
+		check_obsoletes(false), check_regexp_obsoletes(false),
+		check_conflicts(false), check_regexp_conflicts(false),
+		check_requires(false), check_regexp_requires(false),
+		check_recommends(false), check_regexp_recommends(false),
+		check_suggests(false), check_regexp_suggests(false),
+		check_supplements(false), check_regexp_supplements(false),
+		check_enhances(false), check_regexp_enhances(false)
 	{
 		YCPValue kind_symbol = attributes->value(YCPSymbol("kind"));
 		if (!kind_symbol.isNull() && kind_symbol->isSymbol())
@@ -884,6 +895,33 @@ struct ResolvableFilter
 			check_license_confirmed = true;
 			license_confirmed = license_confirmed_value->asBoolean()->value();
 		}
+
+#define QUERY_DEPS(NAME) \
+		YCPValue value_regexp_##NAME = attributes->value(YCPSymbol(#NAME "_regexp")); \
+		if (!value_regexp_##NAME.isNull() && value_regexp_##NAME->isString()) \
+		{ \
+			check_regexp_##NAME = true; \
+			fill_deps(regexp_##NAME, zypp::sat::SolvAttr::NAME, value_regexp_##NAME->asString()->value(), true); \
+		} \
+		\
+		YCPValue str_##NAME = attributes->value(YCPSymbol(#NAME)); \
+		if (!str_##NAME.isNull() && str_##NAME->isString()) \
+		{ \
+			check_##NAME = true; \
+			fill_deps(NAME, zypp::sat::SolvAttr::NAME, str_##NAME->asString()->value(), false); \
+		}
+
+		QUERY_DEPS(provides)
+		QUERY_DEPS(obsoletes)
+		QUERY_DEPS(conflicts)
+		QUERY_DEPS(requires)
+		QUERY_DEPS(recommends)
+		QUERY_DEPS(suggests)
+		QUERY_DEPS(supplements)
+		QUERY_DEPS(enhances)
+
+#undef QUERY_DEPS
+
 	}
 
 	// The main filtering function, returns true/false for each resolvable in the pool
@@ -960,6 +998,25 @@ struct ResolvableFilter
 		if (medium_nr >= 0 && medium_nr != r->mediaNr())
 			return false;
 
+		// check the matching dependencies
+
+#define CHECK_DEPS(NAME) \
+		if (check_##NAME && NAME.find(zypp::sat::Solvable(r)) == NAME.end()) \
+			return false; \
+		if (check_regexp_##NAME && regexp_##NAME.find(zypp::sat::Solvable(r)) == regexp_##NAME.end()) \
+			return false;
+
+		CHECK_DEPS(provides)
+		CHECK_DEPS(obsoletes)
+		CHECK_DEPS(conflicts)
+		CHECK_DEPS(requires)
+		CHECK_DEPS(recommends)
+		CHECK_DEPS(suggests)
+		CHECK_DEPS(supplements)
+		CHECK_DEPS(enhances)
+
+#undef CHECK_DEPS
+
 		return true;
 	}
 
@@ -981,6 +1038,36 @@ struct ResolvableFilter
 	bool check_on_system, on_system;
 	bool check_license_confirmed, license_confirmed;
 	long long medium_nr;
+
+	// define dependency filters
+#define DEFINE_DEPS(NAME) \
+	bool check_##NAME; \
+	bool check_regexp_##NAME; \
+	std::set<zypp::sat::Solvable> regexp_##NAME; \
+	std::set<zypp::sat::Solvable> NAME;
+
+	DEFINE_DEPS(provides)
+	DEFINE_DEPS(obsoletes)
+	DEFINE_DEPS(conflicts)
+	DEFINE_DEPS(requires)
+	DEFINE_DEPS(recommends)
+	DEFINE_DEPS(suggests)
+	DEFINE_DEPS(supplements)
+	DEFINE_DEPS(enhances)
+
+#undef DEFINE_DEPS
+
+private:
+
+    void fill_deps(std::set<zypp::sat::Solvable> &set, zypp::sat::SolvAttr attr, const std::string &query, bool regexp)
+    {
+        zypp::PoolQuery q;
+        regexp ? q.setMatchRegex() : q.setMatchExact();
+        q.addAttribute(attr, query);
+
+        for (zypp::PoolQuery::const_iterator it = q.begin(), end = q.end(); it != end; ++it)
+            set.insert(*it);
+    }
 };
 
 /**
@@ -988,10 +1075,28 @@ struct ResolvableFilter
    @short Is there any resolvable matching the input filter?
    @param map filter
    @param list attrs the list of required attributes
-   @return boolean true if a resolvable was found, false otherwise
+   @return boolean true if a resolvable was found, false otherwise, nil
+	   if an error occurred (call Pkg.LastError() to get the details)
 
    See the ResolvableProperties() call for the accepted filtering keys
    and returned attributes.
+
+	 Additionally it also accepts RPM depency filters, it is possible to check for all
+	 dependency types: provides, obsoletes, conflicts, requires, recommends,
+	 suggests, supplements and enhances.
+
+	 Pass the dependency name as the key (as a string) and the requested text
+	 as the value. You can add "_regexp" suffix, then the value will be used
+	 as a POSIX extended regular expression.
+
+	 Examples (Ruby Hash):
+		 provides: "pattern()"
+		 provides: "release-notes()"
+		 obsoletes_regexp: "^yast2-config-"
+		 supplements_regexp: "^autoyast\\(.*\\)"
+
+	 You can pass several depency filters, in that case the result is logical AND,
+	 i.e. all required dependency filters must match.
 */
 YCPValue PkgFunctions::Resolvables(const YCPMap& filter, const YCPList& attrs)
 {
@@ -1000,8 +1105,15 @@ YCPValue PkgFunctions::Resolvables(const YCPMap& filter, const YCPList& attrs)
 
 	YCPList ret;
 
-	for (const auto &r : zypp::ResPool::instance().filter(ResolvableFilter(filter, *this)) )
-		ret->add(Resolvable2YCPMap(r, false, false, attrs));
+	try {
+        for (const auto &r : zypp::ResPool::instance().filter(ResolvableFilter(filter, *this)) )
+            ret->add(Resolvable2YCPMap(r, false, false, attrs));
+	}
+	catch(const zypp::MatchInvalidRegexException &e)
+	{
+		_last_error.setLastError(ExceptionAsString(e));
+		return YCPVoid();
+	}
 
 	return ret;
 }
@@ -1010,11 +1122,20 @@ YCPValue PkgFunctions::Resolvables(const YCPMap& filter, const YCPList& attrs)
    @builtin AnyResolvable
    @short Is there any resolvable matching the input filter?
    @param map filter
-   @return boolean true if a resolvable was found, false otherwise
+   @return boolean true if a resolvable was found, false otherwise, nil
+	   if an error occurred (call Pkg.LastError() to get the details)
 
    See the ResolvableProperties() call for the accepted filtering keys.
+	 See the Resolvables() call for the details about the dependency filters.
 */
 YCPValue PkgFunctions::AnyResolvable(const YCPMap& filter)
 {
-	return YCPBoolean(!zypp::ResPool::instance().filter(ResolvableFilter(filter, *this)).empty());
+	try {
+		return YCPBoolean(!zypp::ResPool::instance().filter(ResolvableFilter(filter, *this)).empty());
+	}
+	catch(const zypp::MatchInvalidRegexException &e)
+	{
+		_last_error.setLastError(ExceptionAsString(e));
+		return YCPVoid();
+	}
 }


### PR DESCRIPTION
## Summary

- Improve the `Pkg.Resolvables()` call to allow filtering by RPM dependencies (provides, obsoletes,...)
- Related to [bsc#1175317](https://bugzilla.suse.com/show_bug.cgi?id=1175317)
- Example usage: `Pkg.Resolvables({kind: :package, supplements_regexp: "^autoyast\\(.*\\)"}, [:name])`

## Details

- In AutoYaST we need to query all packages for the `autoyast(.*)` supplements, currently we do that in a loop over all packages.
- But the Tumbleweed OSS repository is huge (over 60.000 (!) packages), iterating one-by-one in the Ruby takes veeeery long time...

## Fix

- The fix is to enhance the API to allow filtering by RPM dependencies directly on the libzypp to avoid transferring huge amount of data from libzypp to Ruby.
- The new call takes a fraction of second, the original code took more than half an hour... :alarm_clock: 

## Additional Changes

- The smoke test in Travis is now faster after disabling the huge OSS repository
- The old `Pkg.PkgQueryProvides()` has been marked as obsolete, this improvement supports also the other RPM dependencies and can use a regexp. There is no need for the old call.

## Tests

- Added a smoke test (see the diff)
- Tested manually
- Tested with a helper script

<details>
<summary>Testing code</summary>

```ruby
require "yast"
Yast.import "Pkg"
Yast::Pkg.TargetInitialize("/")
Yast::Pkg.TargetLoad
Yast::Pkg.SourceRestore
Yast::Pkg.SourceLoad

require "y2packager/resolvable"

puts "Provides XFree86: " + Y2Packager::Resolvable.find(
  provides: "XFree86").map(&:name).sort.uniq.inspect
puts
puts "Obsoletes yast2-config: " + Y2Packager::Resolvable.find(
  obsoletes_regexp: "^yast2-config-").map(&:name).sort.uniq.inspect
puts
puts "Supplements autoyast(): " + Y2Packager::Resolvable.find(
  supplements_regexp: "^autoyast\\(.*\\)").map(&:name).sort.uniq.inspect
```

</details>


<details>
<summary>Output</summary>

```
Provides XFree86: ["xorg-x11"]

Obsoletes yast2-config: ["autoyast2", "yast2-firewall", "yast2-nfs-client", "yast2-nis-client", "yast2-nis-server", "yast2-online-update", "yast2-security", "yast2-sound", "yast2-sysconfig", "yast2-tune"]

Supplements autoyast(): ["yast2-add-on", "yast2-audit-laf", "yast2-auth-client", "yast2-bootloader", "yast2-cluster", "yast2-configuration-management", "yast2-dhcp-server", "yast2-dns-server", "yast2-drbd", "yast2-fcoe-client", "yast2-firewall", "yast2-firstboot", "yast2-ftp-server", "yast2-geo-cluster", "yast2-http-server", "yast2-iplb", "yast2-iscsi-client", "yast2-isns", "yast2-kdump", "yast2-mail", "yast2-nfs-client", "yast2-nfs-server", "yast2-nis-client", "yast2-nis-server", "yast2-ntp-client", "yast2-online-update-configuration", "yast2-printer", "yast2-proxy", "yast2-registration", "yast2-samba-client", "yast2-samba-server", "yast2-security", "yast2-services-manager", "yast2-slp-server", "yast2-sound", "yast2-squid", "yast2-support", "yast2-sysconfig", "yast2-tftp-server", "yast2-vpn"]
```

</details>


## TODO

- [ ] Update the AutoYaST code to use this new filter
- [ ] Announce the new filter on yast-devel@ ML