### PR TITLE
Return "nil" when a product package is not defined (bsc#1175681)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct  5 07:27:39 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Return "nil" when a product package is not defined, missing
+  value might cause a crash (bsc#1175681)
+- 4.3.2
+
+-------------------------------------------------------------------
 Fri Sep 25 07:54:14 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed migration from SLE-HPC-12 with activated HPC module to

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -428,30 +428,38 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
 		std::string product_file;
 
 		// add reference file in /etc/products.d
-		if (status.isInstalled() && (all || attrs->contains(YCPSymbol("upgrades"))))
+		if (all || attrs->contains(YCPSymbol("upgrades")))
 		{
-			product_file = (_target_root + "/etc/products.d/" + product->referenceFilename()).asString();
-			y2milestone("Parsing product file %s", product_file.c_str());
-			const zypp::parser::ProductFileData productFileData = zypp::parser::ProductFileReader::scanFile(product_file);
-
-			YCPList upgrade_list;
-
-			for (const auto &upgrade : productFileData.upgrades())
+			if (status.isInstalled())
 			{
-				YCPMap upgrades;
-				upgrades->add(YCPString("name"), YCPString(upgrade.name()));
-				upgrades->add(YCPString("summary"), YCPString(upgrade.summary()));
-				upgrades->add(YCPString("repository"), YCPString(upgrade.repository()));
-				upgrades->add(YCPString("notify"), YCPBoolean(upgrade.notify()));
-				upgrades->add(YCPString("status"), YCPString(upgrade.status()));
-				upgrades->add(YCPString("product"), YCPString(upgrade.product()));
+				product_file = (_target_root + "/etc/products.d/" + product->referenceFilename()).asString();
+				y2milestone("Parsing product file %s", product_file.c_str());
+				const zypp::parser::ProductFileData productFileData = zypp::parser::ProductFileReader::scanFile(product_file);
 
-				upgrade_list->add(upgrades);
+				YCPList upgrade_list;
+
+				for (const auto &upgrade : productFileData.upgrades())
+				{
+					YCPMap upgrades;
+					upgrades->add(YCPString("name"), YCPString(upgrade.name()));
+					upgrades->add(YCPString("summary"), YCPString(upgrade.summary()));
+					upgrades->add(YCPString("repository"), YCPString(upgrade.repository()));
+					upgrades->add(YCPString("notify"), YCPBoolean(upgrade.notify()));
+					upgrades->add(YCPString("status"), YCPString(upgrade.status()));
+					upgrades->add(YCPString("product"), YCPString(upgrade.product()));
+
+					upgrade_list->add(upgrades);
+				}
+
+				info->add(YCPString("upgrades"), upgrade_list);
 			}
-
-			info->add(YCPString("upgrades"), upgrade_list);
+			else if (attrs->contains(YCPSymbol("upgrades")))
+			{
+				info->add(YCPString("upgrades"), YCPVoid());
+			}
 		}
-		else
+
+		if (all || attrs->contains(YCPSymbol("product_package")))
 		{
 			// get the package
 			zypp::sat::Solvable refsolvable = product->referencePackage();
@@ -482,7 +490,15 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
 						}
 					}
 				}
-	    	}
+				else if (attrs->contains(YCPSymbol("product_package")))
+				{
+					info->add(YCPString("product_package"), YCPVoid());
+				}
+	    }
+			else if (attrs->contains(YCPSymbol("product_package")))
+			{
+				info->add(YCPString("product_package"), YCPVoid());
+			}
 		}
 
 		if (all || attrs->contains(YCPSymbol("product_file")))


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1175681, a missing value might cause a crash
- This should be a better fix than https://github.com/yast/yast-yast2/pull/1107
- 4.3.2

## Test

Tested manually, before the fix:

```
irb(main):028:0> Y2Packager::Resolvable.find(kind: :product).last
=> #<Y2Packager::Resolvable:0x000055f06beb23d0 @arch="x86_64", @kind=:product, @name="TEST-addon", @source=21, @version="1.0-0">
irb(main):029:0> Y2Packager::Resolvable.find(kind: :product).last.product_package
Traceback (most recent call last):
        3: from /usr/bin/irb:11:in `<main>'
        2: from (irb):29
        1: from /usr/share/YaST2/lib/y2packager/resolvable.rb:123:in `method_missing'
NoMethodError (undefined method `product_package' for #<Y2Packager::Resolvable:0x000055f06be75f98>)
```

With the fix:

```
irb(main):025:0> Y2Packager::Resolvable.find(kind: :product).last
=> #<Y2Packager::Resolvable:0x00005605cb7cbee8 @arch="x86_64", @kind=:product, @name="TEST-addon", @source=21, @version="1.0-0">
irb(main):026:0> Y2Packager::Resolvable.find(kind: :product).last.product_package
=> nil
```