### PR TITLE
Return "nil" when a product package is not defined (bsc#1175681)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct  5 07:27:39 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Return "nil" when a product package is not defined, missing
+  value might cause a crash (bsc#1175681)
+- 4.2.10
+
+-------------------------------------------------------------------
 Mon Aug 17 07:23:30 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed migration from SLE-HPC-12 with activated HPC module to

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Resolvable_Properties.cc
+++ b/src/Resolvable_Properties.cc
@@ -425,30 +425,38 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
 		std::string product_file;
 
 		// add reference file in /etc/products.d
-		if (status.isInstalled() && (all || attrs->contains(YCPSymbol("upgrades"))))
+		if (all || attrs->contains(YCPSymbol("upgrades")))
 		{
-			product_file = (_target_root + "/etc/products.d/" + product->referenceFilename()).asString();
-			y2milestone("Parsing product file %s", product_file.c_str());
-			const zypp::parser::ProductFileData productFileData = zypp::parser::ProductFileReader::scanFile(product_file);
-
-			YCPList upgrade_list;
-
-			for (const auto &upgrade : productFileData.upgrades())
+			if (status.isInstalled())
 			{
-				YCPMap upgrades;
-				upgrades->add(YCPString("name"), YCPString(upgrade.name()));
-				upgrades->add(YCPString("summary"), YCPString(upgrade.summary()));
-				upgrades->add(YCPString("repository"), YCPString(upgrade.repository()));
-				upgrades->add(YCPString("notify"), YCPBoolean(upgrade.notify()));
-				upgrades->add(YCPString("status"), YCPString(upgrade.status()));
-				upgrades->add(YCPString("product"), YCPString(upgrade.product()));
+				product_file = (_target_root + "/etc/products.d/" + product->referenceFilename()).asString();
+				y2milestone("Parsing product file %s", product_file.c_str());
+				const zypp::parser::ProductFileData productFileData = zypp::parser::ProductFileReader::scanFile(product_file);
 
-				upgrade_list->add(upgrades);
+				YCPList upgrade_list;
+
+				for (const auto &upgrade : productFileData.upgrades())
+				{
+					YCPMap upgrades;
+					upgrades->add(YCPString("name"), YCPString(upgrade.name()));
+					upgrades->add(YCPString("summary"), YCPString(upgrade.summary()));
+					upgrades->add(YCPString("repository"), YCPString(upgrade.repository()));
+					upgrades->add(YCPString("notify"), YCPBoolean(upgrade.notify()));
+					upgrades->add(YCPString("status"), YCPString(upgrade.status()));
+					upgrades->add(YCPString("product"), YCPString(upgrade.product()));
+
+					upgrade_list->add(upgrades);
+				}
+
+				info->add(YCPString("upgrades"), upgrade_list);
 			}
-
-			info->add(YCPString("upgrades"), upgrade_list);
+			else if (attrs->contains(YCPSymbol("upgrades")))
+			{
+				info->add(YCPString("upgrades"), YCPVoid());
+			}
 		}
-		else
+
+		if (all || attrs->contains(YCPSymbol("product_package")))
 		{
 			// get the package
 			zypp::sat::Solvable refsolvable = product->referencePackage();
@@ -479,7 +487,15 @@ YCPMap PkgFunctions::Resolvable2YCPMap(const zypp::PoolItem &item, bool all, boo
 						}
 					}
 				}
-	    	}
+				else if (attrs->contains(YCPSymbol("product_package")))
+				{
+					info->add(YCPString("product_package"), YCPVoid());
+				}
+	    }
+			else if (attrs->contains(YCPSymbol("product_package")))
+			{
+				info->add(YCPString("product_package"), YCPVoid());
+			}
 		}
 
 		if (all || attrs->contains(YCPSymbol("product_file")))


### PR DESCRIPTION
Missing value might cause a crash
