### PR TITLE
Removed zypp::IdString conversion from vendor string.

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov  2 12:38:28 CET 2020 - schubi@suse.de
+
+- Removed zypp::IdString conversion from vendor string.
+  (Part from jsc#SLE-15184)
+- 4.2.12
+
+-------------------------------------------------------------------
 Mon Oct  5 08:27:39 UTC 2020 - schubi@suse.de
 - Added new call Pkg::SetAdditionalVendors (jsc#SLE-15184).
 - 4.2.11

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -1974,7 +1974,7 @@ PkgFunctions::SetAdditionalVendors (const YCPList &vendorycplist)
     {
 	if (vendorycplist->value(i)->isString())
 	{
-	  vendors.push_back((zypp::IdString) vendorycplist->value(i)->asString()->value());
+	  vendors.push_back(vendorycplist->value(i)->asString()->value());
 	}
 	else
 	{


### PR DESCRIPTION
Reverting
https://github.com/yast/yast-pkg-bindings/pull/144/commits/3213ed16eb92293997607b0aa049ac786f601447
which is in SLES15-SP2 only