### PR TITLE
Add a hint to the "locked" error message (gh#yast/yast-yast2#1102)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  3 08:53:18 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Add a hint to the "locked" error message
+  (gh#yast/yast-yast2#1102)
+- 4.3.4
+
+-------------------------------------------------------------------
 Mon Oct  5 08:27:39 UTC 2020 - schubi@suse.de
 
 - Added new call Pkg::SetAdditionalVendors (jsc#SLE-15184).

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -181,8 +181,18 @@ PkgFunctions::Connect()
     }
     catch(const zypp::ZYppFactoryException &excpt)
     {
-	y2error("Error in Connect: FactoryException: %s", excpt.asString().c_str());
-	_last_error.setLastError(excpt.asString());
+        std::string msg(excpt.asString());
+        y2error("Error in Connect: FactoryException: %s", msg.c_str());
+
+        // running "/usr/bin/ruby.ruby2.5" application is not a good hint for users,
+        // very likely it is another YaST instance already running,
+        // add a hint to the error message from libzypp
+        if (excpt.lockerName().find("ruby") != std::string::npos)
+        {
+            msg += std::string("\n\n") + _("Maybe another YaST application is already running?");
+        }
+
+        _last_error.setLastError(msg);
     }
     catch (const zypp::Exception& excpt)
     {


### PR DESCRIPTION
- A fix for issue https://github.com/yast/yast-yast2/issues/1102 - the `/usr/bin/ruby.ruby2.5` application does not tell much to most users.
- We cannot change the original message (it comes from [libzypp](https://github.com/openSUSE/libzypp/blob/4c6904a431c7e194f6a612a467869f11523a6053/zypp/ZYppFactory.cc#L398-L399)), but we can add a hint there.
- 4.3.4

![pkg_lock](https://user-images.githubusercontent.com/907998/97967225-3a5b0480-1dbd-11eb-973c-96298cb6eb9d.png)
