### PR TITLE
Expand URL when libzypp expects an expanded URL.

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 01 16:02:16 CEST 2020 - aschnell@suse.com
+
+- Expand URL when libzypp expects an expanded URL. Fixes weird zypp
+  repository name generated during installation. (bsc#1173509)
+- 4.2.13
+
+-------------------------------------------------------------------
 Mon Nov  2 12:38:28 CET 2020 - schubi@suse.de
 
 - Removed zypp::IdString conversion from vendor string.

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -516,9 +516,15 @@ PkgFunctions::ExpandedName(const YCPString& name) const
 	return YCPVoid();
     }
 
+    return YCPString(ExpandedName(name->value()));
+}
+
+
+string PkgFunctions::ExpandedName(const string& name) const
+{
     zypp::RepoVariablesReplacedString replaced_name;
-    replaced_name.raw() = name->value();
-    return YCPString(replaced_name.transformed());
+    replaced_name.raw() = name;
+    return replaced_name.transformed();
 }
 
 
@@ -535,10 +541,16 @@ YCPValue PkgFunctions::ExpandedUrl(const YCPString &url)
         return YCPVoid();
     }
 
-    zypp::RepoVariablesReplacedUrl replacedUrl;
-    replacedUrl.raw() = zypp::Url(url->value());
     // return full URL including the password if present
-    return YCPString(replacedUrl.transformed().asCompleteString());
+    return YCPString(ExpandedUrl(zypp::Url(url->value())).asCompleteString());
+}
+
+
+zypp::Url PkgFunctions::ExpandedUrl(const zypp::Url& url) const
+{
+    zypp::RepoVariablesReplacedUrl replacedUrl;
+    replacedUrl.raw() = url;
+    return replacedUrl.transformed();
 }
 
 

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -852,5 +852,9 @@ class PkgFunctions
 	RepoId LastReportedRepo() const;
 	int LastReportedMedium() const;
 	void SetReportedSource(RepoId repo, int medium);
+
+    string ExpandedName(const string&) const;
+    zypp::Url ExpandedUrl(const zypp::Url&) const;
+
 };
 #endif // PkgFunctions_h

--- a/src/Source_Callbacks.cc
+++ b/src/Source_Callbacks.cc
@@ -19,7 +19,6 @@
  */
 
 /*
-   File:	$Id$
    Author:	Ladislav Slezák <lslezak@novell.com>
    Summary:     Callbacks functions related to repository registration
    Namespace:   Pkg
@@ -162,7 +161,7 @@ zypp::repo::RepoType PkgFunctions::ProbeWithCallbacks(const zypp::Url &url)
     {
 	// probe type of the repository 
 	zypp::RepoManager* repomanager = CreateRepoManager();
-	repotype = repomanager->probe(url);
+	repotype = repomanager->probe(ExpandedUrl(url));
     }
     catch(...)
     {

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -62,7 +62,7 @@ void PkgFunctions::ScanProductsWithCallBacks(const zypp::Url &url)
     try
     {
 	available_products.clear();
-	zypp::productsInMedia(url, available_products);
+	zypp::productsInMedia(ExpandedUrl(url), available_products);
     }
     catch(...)
     {


### PR DESCRIPTION
backport of expand url fix to SLE15 SP2.

trello: https://trello.com/c/6Tc5Fuoc/1960-3-osdistribution-p5-1173712-releasever-in-addonrepositoriesxml-does-not-work