### PR TITLE
Set the previous "distro_target" option (bsc#1176275)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan  4 08:37:18 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Set the previous "distro_target" option when restarting the
+  package manager (bsc#1176275), fixes upgrade from SLE12 via SMT
+- 4.2.14
+
+-------------------------------------------------------------------
 Tue Dec 01 16:02:16 CEST 2020 - aschnell@suse.com
 
 - Expand URL when libzypp expects an expanded URL. Fixes weird zypp

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -225,7 +225,7 @@ zypp::RepoManager* PkgFunctions::CreateRepoManager()
     zypp::RepoManagerOptions repo_manager_options(_target_root);
     y2milestone("Path to repository files: %s", repo_manager_options.knownReposPath.asString().c_str());
 
-    // set the previously configured "target_distro" option
+    // set the previously configured "target_distro" option (bsc#1176275)
     if(!repo_options->value(YCPString("target_distro")).isNull() && repo_options->value(YCPString("target_distro"))->isString())
     {
         std::string target_distro = repo_options->value(YCPString("target_distro"))->asString()->value();

--- a/src/PkgFunctions.cc
+++ b/src/PkgFunctions.cc
@@ -222,10 +222,18 @@ zypp::RepoManager* PkgFunctions::CreateRepoManager()
     if (repo_manager) return repo_manager;
 
     // set path option, use root dir as a prefix for the default directory
-    zypp::RepoManagerOptions repo_options(_target_root);
-    y2milestone("Path to repository files: %s", repo_options.knownReposPath.asString().c_str());
+    zypp::RepoManagerOptions repo_manager_options(_target_root);
+    y2milestone("Path to repository files: %s", repo_manager_options.knownReposPath.asString().c_str());
 
-    repo_manager = new zypp::RepoManager(repo_options);
+    // set the previously configured "target_distro" option
+    if(!repo_options->value(YCPString("target_distro")).isNull() && repo_options->value(YCPString("target_distro"))->isString())
+    {
+        std::string target_distro = repo_options->value(YCPString("target_distro"))->asString()->value();
+        y2milestone("Using target_distro: %s", target_distro.c_str());
+        repo_manager_options.servicesTargetDistro = target_distro;
+    }
+
+    repo_manager = new zypp::RepoManager(repo_manager_options);
     return repo_manager;
 }
 


### PR DESCRIPTION
## Summary

- Set the previous `distro_target` libzypp option when restating the package manager (restoring the repositories)
- Fixes upgrade from SLE12 via SMT
- See https://bugzilla.suse.com/show_bug.cgi?id=1176275#c8


## Testing

Actually I was not able to reproduce the problem even using the same SMT server, maybe the server has been updated in the meantime?

But I at least have manually tested the patch via DUD to make sure there is no regression. I all went fine, the `y2log` contained this expected part:

```
2021-01-04 08:18:13 <1> install(7704) [Pkg] ui/offline_migration_workflow.rb:83 Pkg Builtin called: SourceRestore
2021-01-04 08:18:13 <1> install(7704) [Pkg] PkgFunctions.cc(CreateRepoManager):226 Path to repository files: /mnt/etc/zypp/repos.d
2021-01-04 08:18:13 <1> install(7704) [Pkg] PkgFunctions.cc(CreateRepoManager):232 Using target_distro: sle-15-x86_64
```

So the `target_distro` was properly set when restarting the repository manager.