### PR TITLE
Fixed repository refresh (bsc#1180203)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan  8 11:12:53 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed repository refresh (a bug caused downloading only the index
+  file in some cases) (bsc#1180203)
+- 4.3.6
+
+-------------------------------------------------------------------
 Mon Jan  4 15:27:02 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Set the previous "distro_target" option when restarting the

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -184,9 +184,10 @@ class PkgFunctions
 
       void CallInitDownload(const std::string &task);
       void CallDestDownload();
+      // use "RefreshForced" by default, otherwise libzypp might download only the index file (bsc#1180203)
       void RefreshWithCallbacks(const zypp::RepoInfo &repo,
 	const zypp::ProgressData::ReceiverFnc & progressrcv = zypp::ProgressData::ReceiverFnc(),
-	zypp::RepoManager::RawMetadataRefreshPolicy refresh = zypp::RepoManager::RefreshIfNeeded);
+	zypp::RepoManager::RawMetadataRefreshPolicy refresh = zypp::RepoManager::RefreshForced);
       zypp::repo::RepoType ProbeWithCallbacks(const zypp::Url &url);
       void ScanProductsWithCallBacks(const zypp::Url &url);
       void CallRefreshStarted();
@@ -208,7 +209,7 @@ class PkgFunctions
 
       zypp::Url shortenUrl(const zypp::Url &url);
 
-      // convert Exception to string represenatation
+      // convert Exception to string representation
       std::string ExceptionAsString(const zypp::Exception &e);
 
       YCPValue searchPackage(const YCPString &package, bool installed);

--- a/src/Source_Download.cc
+++ b/src/Source_Download.cc
@@ -417,7 +417,7 @@ PkgFunctions::SourceRefreshHelper (const YCPInteger& id, bool forced)
     {
 	zypp::RepoManager* repomanager = CreateRepoManager();
 	y2milestone("Refreshing metadata '%s'", repo->repoInfo().alias().c_str());
-	RefreshWithCallbacks(repo->repoInfo(), zypp::ProgressData::ReceiverFnc(), forced ? zypp::RepoManager::RefreshForced : zypp::RepoManager::RefreshIfNeeded);
+	RefreshWithCallbacks(repo->repoInfo(), zypp::ProgressData::ReceiverFnc());
 
 	// next stage, increase progress
 	prog_total.incr();


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1180203#c4
- `RefreshIfNeeded` option should not be used here as it expects already valid cache, it only checks and downloads the master index file
- If the cache does not exist then the other files are not downloaded and building the binary cache fails later

### Testing

I was not able to reproduce the original problem but I at least checked that refreshing the repositories works in an installed system. No regression found.