### PR TITLE
Allow filtering resolvables by RPM path (bsc#1178688, bsc#1176276)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.14
+Version:        4.2.15
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 20 09:24:46 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Allow filtering resolvables by RPM path, return RPM path
+  for the product packages (related to bsc#1178688, bsc#1176276)
+- 4.2.15
+
+-------------------------------------------------------------------
 Mon Jan  4 08:37:18 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Set the previous "distro_target" option when restarting the

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.14
+Version:        4.2.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1178688
- Return RPM repository path for the product packages to allow uniquely identifying Product resolvables
- Allow filtering also by the RPM repository path
- See https://github.com/yast/yast-yast2/pull/1131 for more details
- 4.2.15