### PR TITLE
Log more details about the newly added repositories (bsc#1181344)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 28 12:50:29 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Log more details about the newly added repositories
+  (for debugging bsc#1181344)
+- 4.3.8
+
+-------------------------------------------------------------------
 Fri Jan 22 17:21:15 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Allow filtering resolvables by RPM path, return RPM path

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -30,6 +30,7 @@
 #include <PkgFunctions.h>
 #include <PkgProgress.h>
 #include "log.h"
+#include <y2util/Y2SLog.h>
 
 #include <HelpTexts.h>
 
@@ -278,7 +279,9 @@ PkgFunctions::createManagedSource( const zypp::Url & url_r,
     // set packages path
     repo.setPackagesPath(repomanager->packagesPath(repo));
 
-    y2milestone("Adding source '%s' (%s, dir: %s)", repo.alias().c_str(), url.asString().c_str(), path_r.asString().c_str());
+    MIL << "Adding repository:" << std::endl;
+    MIL << repo << std::endl;
+
     // note: exceptions should be caught by the calling code
     RefreshWithCallbacks(repo, subprogrcv_ref);
     progress.NextStage();
@@ -497,6 +500,9 @@ YCPValue PkgFunctions::RepositoryAdd(const YCPMap &params)
     repo.setMetadataPath(metadatapath);
 
     repo.setPackagesPath(repomanager->packagesPath(repo));
+
+    MIL << "Adding repository:" << std::endl;
+    MIL << repo << std::endl;
 
     repos.push_back(new YRepo(repo));
 


### PR DESCRIPTION
- Requested for debugging https://bugzilla.suse.com/show_bug.cgi?id=1181344#c6
- YaST logs more details about the added repositories, we will see if that helps...


### Testing

With this patch the `y2log` then contains these details:

```
Adding repository:
--------------------------------------
- alias       : oss_1
- name        : oss
- enabled     : 1
- autorefresh : 1
- url         : http://download.opensuse.org/update/leap/$releasever/oss/
- path        : /
- type        : rpm-md
- priority    : 99
- gpgcheck    : D(Y) repoD(Y)* sig? pkgD(Y)* 
- keeppackages: 0
- metadataPath: /var/cache/zypp/raw/oss_1
- packagesPath: /var/cache/zypp/packages/oss_1
```