### PR TITLE
Fixed runtime dependencies (added iproute2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: yast-ci-cpp
 
     - name: Install Smoke Test Requirements
-      run: zypper --non-interactive in --no-recommends yast2-ruby-bindings
+      run: zypper --non-interactive in --no-recommends yast2-ruby-bindings iproute2
 
     - name: Smoke Test Preparation
       run: sh smoke_test_prepare.sh

--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 12 09:39:15 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added missing runtime dependencies ("ip" from iproute2
+  is used for network status detection) (bsc#1183439)
+- 4.3.10
+
+-------------------------------------------------------------------
 Thu Mar 11 09:47:26 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Handle properly expansion of invalid url (bsc#1183195)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -34,6 +34,10 @@ BuildRequires:  libxslt
 BuildRequires:  libzypp-devel >= 17.25.0
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 3.1.10
+
+# needed for network detection
+Requires:       iproute2
+Requires:       grep
 
 Summary:	YaST2 - Package Manager Access
 

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -118,7 +118,6 @@ puts "OK (found #{resolvables.size} packages)"
 patterns = Yast::Pkg.Resolvables({kind: :pattern}, [:name])
 raise "Pkg.Resolvables failed!" unless patterns
 raise "No pattern found!" if patterns.empty?
-raise "Pattern devel_yast not found" unless patterns.include?("name" => "devel_yast")
 puts "OK (found #{patterns.size} patterns)"
 
 installed_packages = Yast::Pkg.Resolvables({kind: :package, status: :installed, name: "yast2-core"}, [:name])


### PR DESCRIPTION
- GitHub Action test failed with `sh: ip: command not found` error, see [this build](https://github.com/yast/yast-pkg-bindings/runs/2085189606)
- It turned out that the `ip` tool was missing in the system, but it is used for detecting the network status ([here](https://github.com/yast/yast-pkg-bindings/blob/55e2f7c416195de65403bf55bb3a2a504e5ccbea/src/Network.cc#L50))
- Added as runtime dependency
- Additionally the test made less strict, the `yast_devel` might or might not be available, depending which repositories are configured. At finding at least one pattern should be sufficient.
- https://bugzilla.suse.com/show_bug.cgi?id=1183439