### PR TITLE
Removed not working PkgFunctions::AddAuthData()

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.10
+Version:        4.4.0
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Apr  7 15:32:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed not working PkgFunctions::AddAuthData(), it is not needed
+  anymore (gh#yast/yast-pkg-bindings#107)
+- Do not try to modify the repository URL, return the libzypp
+  value directly
+- 4.4.0
+
+-------------------------------------------------------------------
 Fri Mar 12 09:39:15 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added missing runtime dependencies ("ip" from iproute2

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.10
+Version:        4.4.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -276,8 +276,6 @@ class PkgFunctions
       // it finds the resolvable using attributes saved earlier by RememberBaseProduct
       zypp::Product::constPtr FindInstalledBaseProduct();
 
-      // adds authentication data to a URL
-      void AddAuthData(zypp::Url url);
       // helper with common code to SourceURL and SourceRawUrl
       YCPValue GetSourceUrl(const YCPInteger& id, bool raw);
       // helper - convert transaction_by to string

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -439,49 +439,6 @@ PkgFunctions::SourceEditGet ()
     return ret;
 }
 
-// Adds authentication data to the URL if it exists
-void
-PkgFunctions::AddAuthData (zypp::Url url) {
-    zypp::media::CredentialManager cm;
-
-	zypp::media::AuthData_Ptr auth = cm.getCred(url);
-
-	if (auth)
-	{
-	    y2milestone("Authentication data found, adding to URL...");
-
-	    if (auth->valid())
-	    {
-		if (!auth->username().empty())
-		{
-		    y2debug("Adding username...");
-		    url.setUsername(auth->username());
-		}
-
-		if (!auth->password().empty())
-		{
-		    y2debug("Adding password...");
-		    url.setPassword(auth->password());
-		}
-	    }
-	    else
-	    {
-		y2warning("Invalid authentication data, returning URL without username and password");
-	    }
-
-	    // does the url contain credentials query?
-	    zypp::url::ParamMap params = url.getQueryStringMap();
-	    zypp::url::ParamMap::iterator map_it = params.find("credentials");
-
-	    if (map_it != params.end())
-	    {
-		y2milestone("Removing credentials query from URL");
-		params.erase(map_it);
-		url.setQueryStringMap(params);
-	    }
-	}
-}
-
 // Helper with common code to SourceURL and SourceRawUrl
 YCPValue
 PkgFunctions::GetSourceUrl (const YCPInteger& id, bool raw)
@@ -500,7 +457,6 @@ PkgFunctions::GetSourceUrl (const YCPInteger& id, bool raw)
             // #186842
             url = repo->repoInfo().url();
         }
-        AddAuthData(url);
     }
 
     return YCPString(url.asCompleteString());


### PR DESCRIPTION
## The Problem

- Reported in #107 
- The function should replace the `credentials` URL parametr with the direct user name and password in the URL
- But because the parameter is passed by value (not by a reference) it modifies *a copy* of the URL which is then not used at all
- In the end the function is just a dead code without any effect

## The History

- The bug has been introduced in #50 in SLE12-SP1 (6 years ago)
- In #54 it has been backported to SLE12-GA Updates
- The functionality was originally added because of the YaST Image Creator module
  - There was a problem when exporting the repository URLs into a KIWI profile
  - KIWI does not support credential files, moreover you can run the KIWI build on another machine which might contain different  credentials or the credentials file might be completely missing
  - See https://fate.suse.com/303652

## The Removal

Lets remove the function:

- The bug is 6 years old, practically it's there since SLE12-GA and nobody noticed the problem
- The Image Creator module, for which the functionality was introduced, has been dropped
- YaST should not modify the URL from libzypp, this can potentially cause problems when e.g. comparing the URLs from SCC and from the system
- If some module really needs the credentials directly in the URL it can reimplement the old pkg-bindings functionality
- It is less secure, the credential files are readable only by the `root` user, using or displaying the URLs with username and password might potentially leak sensitive data