### PR TITLE
[SP2] ProvidePackage() - download the latest package version (bsc#1185240)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Apr 27 08:23:29 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Pkg.ProvidePackage() - download the latest package version from
+  the repository, this ensures that the installer is updated with
+  the latest packages from the installer updates repository
+  (bsc#1185240)
+- 4.2.16
+
+-------------------------------------------------------------------
 Wed Jan 20 09:24:46 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Allow filtering resolvables by RPM path, return RPM path

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -3154,11 +3154,17 @@ zypp::Package::constPtr PkgFunctions::packageFromRepo(const YCPInteger & repo_id
   zypp::Repository repository(zypp::ResPool::instance().reposFind(repo->repoInfo().alias()));
 
   if (repository == zypp::Repository::noRepository)
+  {
+    y2error("Repository %lld not found", repo_id->value());
     return NULL;
+  }
 
   zypp::ui::Selectable::Ptr s = zypp::ui::Selectable::get(name->value());
   if (!s)
+  {
+    y2error("Package %s not found", name->value().c_str());
     return NULL;
+  }
 
   return zypp::asKind<zypp::Package>(s->candidateObjFrom(repository).resolvable());
 }


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1185240 (esp. comments [c#10](https://bugzilla.suse.com/show_bug.cgi?id=1185240#c10) and [c#11](https://bugzilla.suse.com/show_bug.cgi?id=1185240#c11))
- It downloaded the first found package from the repository, that might not be the latest version of the package
- That makes troubles in the self-update, it could download older package resulting in a not fully patched system or could cause crash (when downloading mismatching libraries like `pkg-bindings` and `libzypp`).
- Tested manually in an `irb` session (I could not reproduce the reported problem, but now it downloads the latest version)