### PR TITLE
[SP3] ProvidePackage() - download the latest package version (bsc#1185240)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 License:        GPL-2.0-only
 Group:          Documentation/HTML

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Apr 27 08:23:29 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Pkg.ProvidePackage() - download the latest package version from
+  the repository, this ensures that the installer is updated with
+  the latest packages from the installer updates repository
+  (bsc#1185240)
+- 4.3.11
+
+-------------------------------------------------------------------
 Fri Mar 12 09:39:15 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added missing runtime dependencies ("ip" from iproute2

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -3157,17 +3157,25 @@ YCPValue PkgFunctions::CreateSolverTestCase(const YCPString &dir)
  * @return zypp::Package::constPtr
  */
 zypp::Package::constPtr PkgFunctions::packageFromRepo(const YCPInteger & repo_id, const YCPString & name) {
-  zypp::ResPool pool(zypp::getZYpp()->pool());
   YRepo_Ptr repo = logFindRepository(repo_id->value());
-  if (!repo) return NULL;
+  if (!repo || name.isEmpty()) return NULL;
 
-  /* maybe we should use std::find_if */
-  for_(it, pool.byIdentBegin<zypp::Package>(name->value()), pool.byIdentEnd<zypp::Package>(name->value())) {
-    if (repo->repoInfo().alias() == (*it)->repository().alias()) {
-      return zypp::asKind<zypp::Package>((*it).resolvable());
-    }
+  zypp::Repository repository(zypp::ResPool::instance().reposFind(repo->repoInfo().alias()));
+
+  if (repository == zypp::Repository::noRepository)
+  {
+    y2error("Repository %lld not found", repo_id->value());
+    return NULL;
   }
-  return NULL;
+
+  zypp::ui::Selectable::Ptr s = zypp::ui::Selectable::get(name->value());
+  if (!s)
+  {
+    y2error("Package %s not found", name->value().c_str());
+    return NULL;
+  }
+
+  return zypp::asKind<zypp::Package>(s->candidateObjFrom(repository).resolvable());
 }
 
 /**


### PR DESCRIPTION
- This just merges the #159 to the SP3 branch
- The GitHub action fails in the smoke test, no `yast2-config-*` obsolete was found - the problem was that the YaST packages were not synced to (YaST:SLE-15:SP3)[https://build.opensuse.org/project/monitor/YaST:SLE-15:SP3] so there was no such `Obsoletes`
-  I have synchronized the packages but the full YaST rebuild will take some time... We can ignore the failure now, I'll manually restart the build later.