### PR TITLE
Use the C++17 standard (bsc#1191829)

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -27,5 +27,9 @@ if test \
 fi
 
 AX_CHECK_DOCBOOK
+
+# libzypp uses the C++17 standard
+CXXFLAGS="${CXXFLAGS} -std=c++17"
+
 ## and generate the output
 @YAST2-OUTPUT@

--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 19 12:24:39 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use the C++17 standard, required by the latest libzypp
+  (bsc#1191829)
+- 4.4.3
+
+-------------------------------------------------------------------
 Wed May  5 06:53:20 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Pkg.ProvidePackage() - download the latest package version from

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only


### PR DESCRIPTION
- The pkg-bindings failed in staging: https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:D/yast2-pkg-bindings/standard/x86_64
- Required by the latest libzypp
- 4.4.3