### PR TITLE
Pkg.SourceGeneralData() - return the *.repo file name (bsc#1194546)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 11 08:47:20 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Pkg.SourceGeneralData() - return the file name from which the
+  repository was loaded (related to bsc#1194546)
+- 4.4.4
+
+-------------------------------------------------------------------
 Tue Oct 19 12:24:39 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Use the C++17 standard, required by the latest libzypp

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -72,6 +72,13 @@ raise "Pkg.SourceGetCurrent failed!" unless repos
 raise "No repository found!" if repos.empty?
 puts "OK (found #{repos.size} repositories)"
 
+# Check the repository properties
+puts "Checking Pkg.SourceGeneralData..."
+repo_data = Yast::Pkg.SourceGeneralData(repos.first)
+repo_path = repo_data["file"]
+raise "Unexpected repository location: #{repo_path.inspect}" unless repo_path&.start_with?("/etc/zypp/repos.d/")
+puts "OK (the first repository was read from #{repo_path})"
+
 # Check all packages - this expects at least one package is available/installed
 puts "Checking Pkg.ResolvableProperties..."
 packages = Yast::Pkg.ResolvableProperties("", :package, "")

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -113,6 +113,7 @@ PkgFunctions::SourceGetCurrent (const YCPBoolean& enabled)
  * "alias"	: YCPString,
  * "name"	: YCPString,
  * "raw_name"	: YCPString (raw name without variable replacement),
+ * "file"       : YCPString (source *.repo file when loaded from disk or empty string when created in memory)
  * "service"	: YCPString, (service to which the repo belongs, empty if there is no service assigned)
  * "keeppackages" : YCPBoolean,
  * "is_update_repo" : YCPBoolean, (true if this is an update repo - this requires loaded objects in pool otherwise the flag is not returned! The value is stored in repo metadata, not in .repo file!)
@@ -151,6 +152,8 @@ PkgFunctions::SourceGeneralData (const YCPInteger& id)
 
     data->add( YCPString("name"),		YCPString(repo->repoInfo().name()));
     data->add( YCPString("raw_name"),		YCPString(repo->repoInfo().rawName()));
+
+    data->add(YCPString("file"), YCPString(repo->repoInfo().filepath().asString()));
 
     YCPList base_urls;
     for( zypp::RepoInfo::urls_const_iterator it = repo->repoInfo().baseUrlsBegin(); it != repo->repoInfo().baseUrlsEnd(); ++it)


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1194546
- At the end of installation YaST adds extra repositories specified in the `control.xml`, it also checks whether some extra repository is already present to avoid duplicates
- However, the problem is that the `openSUSE-release` package adds some extra repositories via `*.repo` files. And because these are added outside YaST/libzypp YaST is not aware of them and does not detect duplicates correctly.
- Unfortunately we cannot simply just reload the repositories from the disk as that would lose the installation repositories which were not saved to disk yet.
- So the fix is to save the repositories and *then* detect and remove the duplicates. But when we detect a duplicate we need to remove the repository which is located in the `*.repo_1` file and keep the repository from the `*.repo` file.
- And for that we need to know the file location.

## Testing

- Tested manually
- Added a simple integration test