### PR TITLE
Allow querying orphaned packages (bsc#1202007)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 14 17:41:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Allow querying orphaned packages (related to bsc#1202007)
+- 4.4.5
+
+-------------------------------------------------------------------
 Fri Feb 11 08:47:20 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Pkg.SourceGeneralData() - return the file name from which the

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- At upgrade the orphaned packages are removed, this might include 3rd party packages like Oracle database
- The removal is silent, no warning is displayed, if user does not check the details in the package manager then a nasty surprise might happen... :rage: 
- https://bugzilla.suse.com/show_bug.cgi?id=1202007

## Solution

- Display a warning in the upgrade summary
- For that we need to be able to query orphaned packages from libzypp
- Libzypp has similar flags `recommended`, `suggested` and `unneeded`, let's support them too, they might be useful in the future
- The `Pkg.ResolvableProperties` call now returns the status of these additional flags and the `Pkg.Resolvables` call can filter the resolvables by these new flags
- See related https://github.com/yast/yast-update/pull/184

## Testing

- Tested manually

## Screenshots

Using this new filtering options we can display a warning in the summary when removing non-SUSE packages:

![upgrade_warning](https://user-images.githubusercontent.com/907998/201882056-388465e8-aed7-48a4-8dcc-4dbf7bc3c236.png)

