### PR TITLE
Pkg.TargetInitializeOptions() - added option for rebuilding the RPM DB

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 12 07:36:47 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Pkg.TargetInitializeOptions() - added a new option for
+  rebuilding the RPM database (--rebuilddb) (bsc#1209565)
+- 4.5.2
+
+-------------------------------------------------------------------
 Wed Nov 16 14:08:26 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Allow querying orphaned packages (related to bsc#1202007) 

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/src/Target_Load.cc
+++ b/src/Target_Load.cc
@@ -143,9 +143,10 @@ PkgFunctions::TargetInitialize (const YCPString& root)
  * @short Initialize Target, read the keys, set the repomanager options
  * @param string root Root Directory
  * @param map options for RepoManager
- *   supproted keys:
+ *   supported keys:
  *   "target_distro": <string> - override the target distribution autodetection,
  *     example values: "sle-11-x86_84", "sle-12-x86_84"
+ *   "rebuild_db": <boolean> - rebuild the RPM DB if set to `true`
  * @return boolean
  */
 YCPValue
@@ -155,7 +156,21 @@ PkgFunctions::TargetInitializeOptions (const YCPString& root, const YCPMap& opti
 
     try
     {
-        zypp_ptr()->initializeTarget(r);
+        // do not rebuild the RPM DB by default
+        bool rebuild_db = false;
+
+        YCPString rebuild_db_key("rebuild_db");
+        YCPValue rebuild_db_value = options->value(rebuild_db_key);
+        if (!rebuild_db_value.isNull() && rebuild_db_value->isBoolean())
+        {
+            rebuild_db = rebuild_db_value->asBoolean()->value();
+        }
+
+        if (rebuild_db) {
+            y2milestone("RPM DB rebuild is enabled");
+        }
+
+        zypp_ptr()->initializeTarget(r, rebuild_db);
         SetTarget(r, options);
     }
     catch (zypp::Exception & excpt)


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1209565
- The RPM DB should be rebuilt during upgrade to ensure it is in a consistent state

## Solution

- The `Pkg.TargetInitializeOptions()` call accepts a Hash with options passed to libzypp, let's extend that with a rebuild DB flag

## Testing

- Tested manually with both manual upgrade and auto upgrade using AutoYaST

