### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.3
 
 -------------------------------------------------------------------
 Wed Apr 12 07:36:47 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -2,7 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
-- 4.6.3
+- 4.6.0
 
 -------------------------------------------------------------------
 Wed Apr 12 07:36:47 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.6.0
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.6.3
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.

## Solution

Just bump version.

- https://github.com/yast/yast-pkg-bindings/pull/176 drop is not for SLE15
- https://github.com/yast/yast-pkg-bindings/pull/173 is already in SP5