### PR TITLE
Fixed crash in the Pkg.Commit() function (bsc#1215238)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 13 15:09:36 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed crash in the Pkg.Commit() function when passing
+  "exclude_docs" or "no_signature" options (bsc#1215238)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -2500,12 +2500,12 @@ YCPValue PkgFunctions::Commit (const YCPMap& config)
                 bool exclude_docs = config->value(key)->asBoolean()->value();
                 commit_policy->rpmExcludeDocs(exclude_docs);
 
-                y2milestone("Excluding documentation: %s", config->value(key)->asString()->value().c_str());
+                y2milestone("Excluding documentation: %s", config->value(key)->toString().c_str());
             }
             else
             {
-                y2error("Exclude documentation option: boolean is required, got: %s", config->value(key)->asString()->value().c_str());
-                _last_error.setLastError(std::string("Invalid exclude documentation option: ") + config->value(key)->asString()->value());
+                y2error("Exclude documentation option: boolean is required, got: %s", config->value(key)->toString().c_str());
+                _last_error.setLastError(std::string("Invalid exclude documentation option: ") + config->value(key)->toString());
 
 		delete commit_policy;
 		commit_policy = NULL;
@@ -2523,12 +2523,12 @@ YCPValue PkgFunctions::Commit (const YCPMap& config)
                 bool no_signature = config->value(key)->asBoolean()->value();
                 commit_policy->rpmNoSignature(no_signature);
 
-                y2milestone("Don't check RPM signature: %s", config->value(key)->asString()->value().c_str());
+                y2milestone("Don't check RPM signature: %s", config->value(key)->toString().c_str());
             }
             else
             {
-                y2error("No signature option: boolean is required, got: %s", config->value(key)->asString()->value().c_str());
-                _last_error.setLastError(std::string("Invalid no signature option: ") + config->value(key)->asString()->value());
+                y2error("No signature option: boolean is required, got: %s", config->value(key)->toString().c_str());
+                _last_error.setLastError(std::string("Invalid no signature option: ") + config->value(key)->toString());
 
 		delete commit_policy;
 		commit_policy = NULL;


### PR DESCRIPTION
## Problem

- The `Yast::Pkg.Commit({"exclude_docs" => false})` call crashes (aborts the process)
- https://bugzilla.suse.com/show_bug.cgi?id=1215238

## Solution

- Use the correct method when logging the value

## Testing

- Tested manually

## Details

- The `asString()` method converts an `YCPValue` to `YCPString`, but if the value is not a string then it aborts
- The correct method is `toString()` which converts an `YCPValue` to a string representation (works also for maps, arrays, etc...)
- The problem happens for parameters "exclude_docs" and "no_signature" which are currently not used in any YaST code
