### PR TITLE
Set version to 4.6.3

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.6.1
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -3,7 +3,7 @@ Wed Sep 13 15:09:36 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed crash in the Pkg.Commit() function when passing
   "exclude_docs" or "no_signature" options (bsc#1215238)
-- 4.6.1
+- 4.6.3
 
 -------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.6.1
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only


### PR DESCRIPTION
- Version 4.6.1 and 4.6.2 were already used in the past in master (https://github.com/yast/yast-pkg-bindings/blob/master/package/yast2-pkg-bindings.changes)
- Use 4.6.3
