### PR TITLE
[SLE-15-SP6] Pkg.SourceEditSet() - Allow setting the service name (bsc#1214135)

### DIFF
--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.6.3
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 20 08:57:18 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Pkg.SourceEditSet() - Allow setting the repository service name
+  (related to bsc#1214135)
+- 4.6.4
+
+-------------------------------------------------------------------
 Wed Sep 13 15:09:36 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed crash in the Pkg.Commit() function when passing

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.6.3
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/src/Source_Set.cc
+++ b/src/Source_Set.cc
@@ -259,7 +259,7 @@ PkgFunctions::SourceEditSet (const YCPList& states)
     if( !descr->value(YCPString("service")).isNull() && descr->value(YCPString("service"))->isString())
     {
         string service = descr->value(YCPString("service"))->asString()->value();
-	    y2debug("set service: %s", service.c_str());
+        y2debug("set service: %s", service.c_str());
         repo->repoInfo().setService(service);
     }
   }

--- a/src/Source_Set.cc
+++ b/src/Source_Set.cc
@@ -255,6 +255,13 @@ PkgFunctions::SourceEditSet (const YCPList& states)
         y2debug("set keeppackages: %d", keeppackages);
 	repo->repoInfo().setKeepPackages( keeppackages );
     }
+
+    if( !descr->value(YCPString("service")).isNull() && descr->value(YCPString("service"))->isString())
+    {
+        string service = descr->value(YCPString("service"))->asString()->value();
+	    y2debug("set service: %s", service.c_str());
+        repo->repoInfo().setService(service);
+    }
   }
 
   return YCPBoolean( !error );


### PR DESCRIPTION
## Problem

- Related to https://bugzilla.suse.com/show_bug.cgi?id=1214135

## Solution

- To fix that we need to allow changing the `service` attribute in the `Pkg.SourceEditSet()` call

## Testing

- Tested manually, see more details in https://github.com/yast/yast-packager/pull/642
