### PR TITLE
API for solving dependency problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Dependencies
       run: rake build_dependencies:install

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -2,7 +2,7 @@
 Tue Jan 16 14:32:15 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Added new pkg calls for managing and resolving the solver
-  conflits. Added PkgSolveProblems(), PkgSetSolveSolutions()
+  conflicts. Added PkgSolveProblems(), PkgSetSolveSolutions()
   and PkgResetSolveSolutions() calls. (gh#openSUSE/agama#944)
 - Libzypp 17.31.26+ uses "N/A" for unknown repository types
   instead of "NONE", support both cases (bsc#1218859)

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Jan 16 14:32:15 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Added new pkg calls for managing and resolving the solver
+  conflits. Added PkgSolveProblems(), PkgSetSolveSolutions()
+  and PkgResetSolveSolutions() calls. (gh#openSUSE/agama#944)
+- Libzypp 17.31.26+ uses "N/A" for unknown repository types
+  instead of "NONE", support both cases (bsc#1218859)
+- 5.0.3
+
+-------------------------------------------------------------------
 Wed Sep 20 15:54:13 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Pkg.SourceEditSet() - Allow setting the repository service name

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/src/Package.cc
+++ b/src/Package.cc
@@ -2344,6 +2344,8 @@ PkgFunctions::PkgSetSolveSolutions(const YCPList& solutions)
 YCPValue
 PkgFunctions::PkgResetSolveSolutions()
 {
+    // the name is a bit confusing, it does not revert just the last change
+    // but resets everything
     zypp::getZYpp()->resolver()->undo();
     return YCPVoid();
 }

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -695,6 +695,12 @@ class PkgFunctions
 	YCPBoolean PkgSolveCheckTargetOnly ();
 	/* TYPEINFO: integer()*/
 	YCPValue PkgSolveErrors ();
+	/* TYPEINFO: list<map<string,any>>()*/
+	YCPValue PkgSolveProblems ();
+	/* TYPEINFO: boolean(list<map<string,any>>)*/
+	YCPValue PkgSetSolveSolutions (const YCPList& solutions);
+	/* TYPEINFO: void()*/
+	YCPValue PkgResetSolveSolutions ();
         YCPValue CommitHelper(const zypp::ZYppCommitPolicy *policy);
 	/* TYPEINFO: list<any>(integer)*/
 	YCPValue PkgCommit (const YCPInteger& medianr);

--- a/src/Source_Misc.cc
+++ b/src/Source_Misc.cc
@@ -119,6 +119,8 @@ std::string PkgFunctions::zypp2yastType(const std::string &type)
       type_conversion_table["yast2"] = "YaST";
       type_conversion_table["plaindir"] = "Plaindir";
       type_conversion_table["NONE"] = "NONE";
+      // since libzypp-17.31.26
+      type_conversion_table["N/A"] = "NONE";
     }
 
     std::map<std::string,std::string>::const_iterator it = type_conversion_table.find(type);


### PR DESCRIPTION
## Problem

- Users cannot resolve the package conflicts in Agama, in YaST that is done by the packager widget (libyui-*-pkg).
- For Agama we need a new API for that
- See https://github.com/openSUSE/agama/blob/master/doc/research/software-conflicts.md or https://trello.com/c/cnSQ6DmR/3524-3-extend-yast-pkg-bindings-to-improve-conflict-reporting

## Solution

Added several new bindings:
- `PkgSolveProblems` - returns details about the dependency problems and the suggested solutions, the texts are translated using the current locale
- `PkgSetSolveSolutions` - apply one of the selected solution for each dependency problem, use the data returned by the `PkgSolveProblems` call (the locale must not be changed between those two calls otherwise the selected solution will not be found), run the solver after applying the solutions
- `PkgResetSolveSolutions` - clears the previously selected solutions, run the solver after clearing the solutions (note:  the changes done by the previous solutions are still active, e.g. when a solution was to uninstall a package then the package is still selected to uninstall even after resetting the applied solutions. See the example script at the bottom how we could reset the previous solutions in Agama.

See the comments the in code for more details.

## Testing

- Updated integration test
- Tested manually, see the testing code at the bottom

## Notes

### Returned Data

The problems and solutions contain the very same texts as displayed by the YaST conflict solver.

This conflict in YaST:
![conflicts_yast](https://github.com/yast/yast-pkg-bindings/assets/907998/35f932f2-5f1b-4850-8782-6714afab0754)

Is represented as this data returned by the new pkg-bindings:

```ruby
[{"description"=>
   "the to be installed yast2-theme-SLE-4.5.0-lp154.2.1.noarch conflicts with 'namespace:otherproviders(yast2-branding)' provided by the installed yast2-theme-5.0.1-lp154.2.1.noarch",
  "details"=>"",
  "solutions"=>
   [{"description"=>"Following actions will be done:",
     "details"=>
      "deinstallation of yast2-theme-5.0.1-lp154.2.1.noarch\n" +
      "deinstallation of yast2-theme-oxygen-5.0.1-lp154.2.1.noarch\n" +
      "deinstallation of yast2-theme-breeze-5.0.1-lp154.2.1.noarch"},
    {"description"=>"do not install yast2-theme-SLE-4.5.0-lp154.2.1.noarch",
     "details"=>""}]}]
```

### Translations

When running in the Spanish locale the returned texts look like this:

```ruby
[{"description"=>
   "el elemento yast2-theme-SLE-4.5.0-lp154.2.1.noarch que se va a instalar tiene un conflicto con namespace:otherproviders(yast2-branding), que proporciona el elemento yast2-theme-5.0.1-lp154.2.1.noarch instalado",
  "details"=>"",
  "solutions"=>
   [{"description"=>"Se realizarán las siguientes acciones:",
     "details"=>
      "desinstalación de yast2-theme-5.0.1-lp154.2.1.noarch\n" +
      "desinstalación de yast2-theme-oxygen-5.0.1-lp154.2.1.noarch\n" +
      "desinstalación de yast2-theme-breeze-5.0.1-lp154.2.1.noarch"},
    {"description"=>"no instalar yast2-theme-SLE-4.5.0-lp154.2.1.noarch",
     "details"=>""}]}]
```

### Testing Code

<details>
<summary>For testing the dependencies I use this small Ruby script (needs to be run as "root")</summary>

```ruby
#! /usr/bin/env ruby

require "pp"
require "yast"
require "y2packager/resolvable"

Yast.ui_component="qt"
Yast.import "UI"
Yast.import "Pkg"

# Yast.import "PackageCallbacks"
# Yast::PackageCallbacks.InitPackageCallbacks

Yast::Pkg.TargetInitialize("/")
Yast::Pkg.TargetLoad
Yast::Pkg.SourceRestore
Yast::Pkg.SourceLoad

puts "** Initial status"
solver = Yast::Pkg.PkgSolve(false)
puts "Dependencies solved: #{solver.inspect}"
errors = Yast::Pkg.PkgSolveErrors
puts "Solver errors: #{errors}"

puts "-"*25
puts "** Selecting yast2-theme-SLE to install"
Yast::Pkg.ResolvableInstall("yast2-theme-SLE", :package)
solver = Yast::Pkg.PkgSolve(false)
puts "Dependencies solved : #{solver.inspect}"
errors = Yast::Pkg.PkgSolveErrors
puts "Solver errors: #{errors}"

problems = Yast::Pkg.PkgSolveProblems
puts "Solver problems:"
pp problems

puts "-"*25
puts "** Applying the first solution"
problem = problems.first
solution = problem["solutions"].first
Yast::Pkg.PkgSetSolveSolutions(
  [
    {
      "description" => problem["description"],
      "details" => problem["details"],
      "solution_description" => solution["description"],
      "solution_details" => solution["details"]
    }
  ]
)

solver = Yast::Pkg.PkgSolve(false)
puts "Dependencies solved: #{solver.inspect}"
errors = Yast::Pkg.PkgSolveErrors
puts "Solver errors: #{errors}"

puts "-"*25
puts "** Clearing the solutions"

# clear the remembered solutions
Yast::Pkg.PkgResetSolveSolutions

# revert the changes done by the solutions
user_changes = Y2Packager::Resolvable.find(transact_by: :user)
puts "User transactions: #{user_changes.size}"
user_changes.each do |u|
  Yast::Pkg.ResolvableNeutral(u.name, u.kind, true)
end

solver = Yast::Pkg.PkgSolve(false)
puts "Dependencies solved: #{solver.inspect}"
errors = Yast::Pkg.PkgSolveErrors
puts "Solver errors: #{errors}"

problems = Yast::Pkg.PkgSolveProblems
puts "Solver problems:"
pp problems
```

</details>

### Additional Fix

The integration test failed with an error in the `y2log`. It turned out that libzypp [recently](https://github.com/openSUSE/libzypp/commit/1ec09fee6070a350834b143ffdd1baaf4ec0a8e3) changed the repository type "NONE" to "N/A". That caused problems because in YaST this value was missing in the conversion table.

Related to https://bugzilla.suse.com/show_bug.cgi?id=1218859.