### PR TITLE
[SLE15-SP5] Fixed repository and service probing (bsc#1218977, bsc#1218399)

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -29,7 +29,8 @@ fi
 AX_CHECK_DOCBOOK
 
 # libzypp uses the C++17 standard
-CXXFLAGS="${CXXFLAGS} -std=c++17"
+# treat missing values in switch statements as errors
+CXXFLAGS="${CXXFLAGS} -std=c++17 -Werror=switch"
 
 ## and generate the output
 @YAST2-OUTPUT@

--- a/package/yast2-pkg-bindings-devel-doc.spec
+++ b/package/yast2-pkg-bindings-devel-doc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings-devel-doc
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Documentation for yast2-pkg-bindings package
 License:        GPL-2.0-only

--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan 19 13:47:43 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed repository and service probing with libzypp 7.31.26
+  and newer, fixes broken repository handling (bsc#1218977,
+  bsc#1218399)
+- 4.5.3
+
+-------------------------------------------------------------------
 Wed Apr 12 07:36:47 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Pkg.TargetInitializeOptions() - added a new option for

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -149,7 +149,7 @@ class PkgFunctions
       bool remoteRepo(const zypp::Url &url);
 
       // conversion methods for type string between Yast and libzypp (for backward compatibility)
-      std::string zypp2yastType(const std::string &type);
+      std::string zypp2yastType(const zypp::repo::RepoType &type);
       std::string yast2zyppType(const std::string &type);
 
       // helper - create a directory if it doesn't exist

--- a/src/ServiceManager.cc
+++ b/src/ServiceManager.cc
@@ -300,7 +300,17 @@ bool ServiceManager::SetService(const std::string &old_alias, const zypp::Servic
 std::string ServiceManager::Probe(const zypp::Url &url, const zypp::RepoManager &repomgr) const
 {
     y2milestone("Probing service at %s...", url.asString().c_str());
-    std::string ret(repomgr.probeService(url).asString());
+
+    std::string ret;
+
+    zypp::repo::ServiceType type(repomgr.probeService(url));
+    switch (type.toEnum())
+    {
+      case zypp::repo::ServiceType::NONE_e:        ret = "NONE";    break;
+      case zypp::repo::ServiceType::PLUGIN_e:      ret = "plugin";  break;
+      case zypp::repo::ServiceType::RIS_e:         ret = "ris";     break;
+    }
+
     y2milestone("Detected service type: %s", ret.c_str());
 
     return ret;

--- a/src/Source_Create.cc
+++ b/src/Source_Create.cc
@@ -814,7 +814,7 @@ YCPValue PkgFunctions::RepositoryProbe(const YCPString& url, const YCPString& pr
 	// autoprobe type of the repository 
 	zypp::repo::RepoType repotype = ProbeWithCallbacks(probe_url);
 
-	ret = zypp2yastType(repotype.asString());
+	ret = zypp2yastType(repotype);
 	y2milestone("Detected type: '%s'...", ret.c_str());
     }
     catch (const zypp::Exception& excpt)

--- a/src/Source_Get.cc
+++ b/src/Source_Get.cc
@@ -134,7 +134,7 @@ PkgFunctions::SourceGeneralData (const YCPInteger& id)
 	return YCPVoid ();
 
     // convert type to the old strings ("YaST", "YUM" or "Plaindir")
-    std::string srctype = zypp2yastType(repo->repoInfo().type().asString());
+    std::string srctype = zypp2yastType(repo->repoInfo().type());
 
     data->add( YCPString("enabled"),		YCPBoolean(repo->repoInfo().enabled()));
     data->add( YCPString("autorefresh"),	YCPBoolean(repo->repoInfo().autorefresh()));

--- a/src/Source_Misc.cc
+++ b/src/Source_Misc.cc
@@ -108,32 +108,18 @@ bool PkgFunctions::aliasExists(const std::string &alias, const std::list<zypp::R
 }
 
 // convert libzypp type to yast strings ("YaST", "YUM" or "Plaindir")
-std::string PkgFunctions::zypp2yastType(const std::string &type)
+std::string PkgFunctions::zypp2yastType(const zypp::repo::RepoType &type)
 {
-    std::string ret(type);
-
-    if (type_conversion_table.empty())
+    switch (type.toEnum())
     {
-      // initialize the conversion map
-      type_conversion_table["rpm-md"] = "YUM";
-      type_conversion_table["yast2"] = "YaST";
-      type_conversion_table["plaindir"] = "Plaindir";
-      type_conversion_table["NONE"] = "NONE";
+      case zypp::repo::RepoType::NONE_e:        return "NONE";
+      case zypp::repo::RepoType::RPMMD_e:       return "YUM";
+      case zypp::repo::RepoType::YAST2_e:       return "YaST";
+      case zypp::repo::RepoType::RPMPLAINDIR_e: return "Plaindir";
     }
 
-    std::map<std::string,std::string>::const_iterator it = type_conversion_table.find(type);
-
-    // found in the conversion table
-    if (it != type_conversion_table.end())
-    {
-	ret = it->second;
-    }
-    else
-    {
-	y2error("Cannot convert type '%s'", type.c_str());
-    }
-
-    return ret;
+    // never reached, unhandled enums are treated as errors via the -Werror option
+    return "";
 }
 
 std::string PkgFunctions::yast2zyppType(const std::string &type)
@@ -159,7 +145,7 @@ std::string PkgFunctions::UniqueAlias(const std::string &alias)
     {
 	y2milestone("Alias %s already found: %lld", ret.c_str(), logFindAlias(ret));
 
-	// the alias already exists - add a counter 
+	// the alias already exists - add a counter
 	std::ostringstream ostr;
 	ostr << alias << "_" << id;
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1218977 - Installation with the latest self-updates is broken
- It turned out that the problem is the same as in Tumbleweed

## Fix

- Backported fix #184 to SP5

## Testing

- Tested manually, it fixes the problem with using the self update
- I applied the default self update and then overwritten the `usr/lib64/YaST2/plugin/libpy2Pkg.so.2.0.0` file from the RPM built for SP5-Updates.
