### PR TITLE
Support for new libzypp callbacks

### DIFF
--- a/package/yast2-pkg-bindings.changes
+++ b/package/yast2-pkg-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 30 13:52:01 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Add support for the new libzypp install callbacks (bsc#1244319).
+- 5.0.6
+
+-------------------------------------------------------------------
 Fri Jan 31 20:19:20 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Deprecated callbacks that is deprecated and no longer used

--- a/package/yast2-pkg-bindings.spec
+++ b/package/yast2-pkg-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pkg-bindings
-Version:        5.0.5
+Version:        5.0.6
 Release:        0
 Summary:        YaST2 - Package Manager Access
 License:        GPL-2.0-only

--- a/smoke_test_run.rb
+++ b/smoke_test_run.rb
@@ -29,6 +29,9 @@ def check_y2log
   # (when running as non-root)
   y2log.reject! { |l| l =~ /\/var\/lib\/zypp\/LastDistributionFlavor/ }
 
+  # ignore repository mirror errors
+  y2log.reject! { |l| l =~ /Failed to read RepoMirrorList file/ }
+
   # no idea why that happens at Travis, let's ignore that...
   y2log.reject! { |l| l =~ /error: Interrupted system call/ }
 

--- a/src/Callbacks.YCP.cc
+++ b/src/Callbacks.YCP.cc
@@ -58,6 +58,9 @@
 	ENUM_OUT( DoneDownload );
 	ENUM_OUT( InitDownload );
 	ENUM_OUT( DestDownload );
+	ENUM_OUT( StartInstallResolvableSA );
+	ENUM_OUT( ProgressInstallResolvableSA );
+	ENUM_OUT( FinishInstallResolvableSA );
 
 	ENUM_OUT( ScriptStart );
 	ENUM_OUT( ScriptProgress );

--- a/src/Callbacks.YCP.h
+++ b/src/Callbacks.YCP.h
@@ -69,6 +69,7 @@ class PkgFunctions::CallbackHandler::YCPCallbacks
       CB_StartScanDb, CB_ProgressScanDb, CB_ErrorScanDb, CB_DoneScanDb,
       CB_StartProvide, CB_ProgressProvide, CB_DoneProvide,
       CB_StartPackage, CB_ProgressPackage, CB_DonePackage,
+      CB_StartInstallResolvableSA, CB_ProgressInstallResolvableSA, CB_FinishInstallResolvableSA,
 
       CB_SourceCreateStart, CB_SourceCreateProgress, CB_SourceCreateError, CB_SourceCreateEnd,
       CB_SourceCreateInit, CB_SourceCreateDestroy,

--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -141,6 +141,53 @@ namespace ZyppRecipients {
 	}
     };
 
+    ///////////////////////////////////////////////////////////////////
+    // InstallResolvableReportSA callback
+    ///////////////////////////////////////////////////////////////////
+    struct InstallResolvableReportSA : public Recipient, public zypp::callback::ReceiveReport<zypp::target::rpm::InstallResolvableReportSA>
+    {
+			InstallResolvableReportSA( RecipientCtl & construct_r ) : Recipient( construct_r ) {}
+
+			virtual void start(zypp::Resolvable::constPtr resolvable, const UserData &userdata = UserData())
+      {
+		    CB callback( ycpcb( YCPCallbacks::CB_StartInstallResolvableSA ) );
+
+				if (callback._set) {
+					YCPMap data;
+					data->add(YCPString("name"), YCPString(resolvable->name()));
+
+					callback.addMap(data);
+					callback.evaluate();
+				}
+			}
+
+      virtual void progress(int value, zypp::Resolvable::constPtr resolvable, const UserData &userdata = UserData())
+      {
+		    CB callback( ycpcb( YCPCallbacks::CB_ProgressInstallResolvableSA ) );
+
+				if (callback._set) {
+					YCPMap data;
+					data->add(YCPString("name"), YCPString(resolvable->name()));
+
+					callback.addMap(data);
+					callback.addInt(value);
+					callback.evaluate();
+				}
+			}
+
+      virtual void finish(zypp::Resolvable::constPtr resolvable, Error error, const UserData &userdata = UserData())
+			{
+		    CB callback( ycpcb( YCPCallbacks::CB_FinishInstallResolvableSA ) );
+
+				if (callback._set) {
+					YCPMap data;
+					data->add(YCPString("name"), YCPString(resolvable->name()));
+
+					callback.addMap(data);
+					callback.evaluate();
+				}
+			}
+		};
 
     ///////////////////////////////////////////////////////////////////
     // InstallPkgCallback
@@ -1427,6 +1474,7 @@ class PkgFunctions::CallbackHandler::ZyppReceive : public ZyppRecipients::Recipi
     ZyppRecipients::RemovePkgReceive  _removePkgReceive;
     ZyppRecipients::DownloadResolvableReceive _providePkgReceive;
     ZyppRecipients::FileConflictReceive _fileConflictReceive;
+		ZyppRecipients::InstallResolvableReportSA _installResolvableReportSA;
 
     // media callback
     ZyppRecipients::MediaChangeReceive   _mediaChangeReceive;
@@ -1459,6 +1507,7 @@ class PkgFunctions::CallbackHandler::ZyppReceive : public ZyppRecipients::Recipi
       , _removePkgReceive( *this )
       , _providePkgReceive( *this, pkg )
       , _fileConflictReceive( *this )
+			, _installResolvableReportSA( *this )
       , _mediaChangeReceive( *this )
       , _downloadProgressReceive( *this )
       , _scriptExecReceive( *this )
@@ -1475,6 +1524,7 @@ class PkgFunctions::CallbackHandler::ZyppReceive : public ZyppRecipients::Recipi
 	_removePkgReceive.connect();
 	_providePkgReceive.connect();
         _fileConflictReceive.connect();
+	_installResolvableReportSA.connect();
 	_mediaChangeReceive.connect();
 	_downloadProgressReceive.connect();
 	_scriptExecReceive.connect();
@@ -1494,6 +1544,7 @@ class PkgFunctions::CallbackHandler::ZyppReceive : public ZyppRecipients::Recipi
 	_removePkgReceive.disconnect();
 	_providePkgReceive.disconnect();
         _fileConflictReceive.disconnect();
+	_installResolvableReportSA.disconnect();
 	_mediaChangeReceive.disconnect();
 	_downloadProgressReceive.disconnect();
 	_scriptExecReceive.disconnect();

--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -153,10 +153,7 @@ namespace ZyppRecipients {
 		    CB callback( ycpcb( YCPCallbacks::CB_StartInstallResolvableSA ) );
 
 				if (callback._set) {
-					YCPMap data;
-					data->add(YCPString("name"), YCPString(resolvable->name()));
-
-					callback.addMap(data);
+					callback.addMap(resolvable2map(resolvable));
 					callback.evaluate();
 				}
 			}
@@ -166,10 +163,7 @@ namespace ZyppRecipients {
 		    CB callback( ycpcb( YCPCallbacks::CB_ProgressInstallResolvableSA ) );
 
 				if (callback._set) {
-					YCPMap data;
-					data->add(YCPString("name"), YCPString(resolvable->name()));
-
-					callback.addMap(data);
+					callback.addMap(resolvable2map(resolvable));
 					callback.addInt(value);
 					callback.evaluate();
 				}
@@ -180,12 +174,37 @@ namespace ZyppRecipients {
 		    CB callback( ycpcb( YCPCallbacks::CB_FinishInstallResolvableSA ) );
 
 				if (callback._set) {
-					YCPMap data;
-					data->add(YCPString("name"), YCPString(resolvable->name()));
-
-					callback.addMap(data);
+					callback.addMap(resolvable2map(resolvable));
 					callback.evaluate();
 				}
+			}
+
+			private:
+
+			YCPMap resolvable2map(zypp::Resolvable::constPtr resolvable) {
+				YCPMap map;
+				map->add(YCPString("name"), YCPString(resolvable->name()));
+				map->add(YCPString("version"), YCPString(resolvable->edition().asString()));
+				map->add(YCPString("arch"), YCPString(resolvable->arch().asString()));
+				map->add(YCPString("repo_alias"), YCPString(resolvable->repoInfo().alias()));
+
+				string kind;
+				if (resolvable->isKind<zypp::Package>()) {
+					kind = "package";
+				} else if (resolvable->isKind<zypp::Patch>()) {
+					kind = "patch";
+				} else if (resolvable->isKind<zypp::Pattern>()) {
+					kind = "pattern";
+				} else if (resolvable->isKind<zypp::SrcPackage>()) {
+					kind = "srcpackage";
+				} else if (resolvable->isKind<zypp::Product>()) {
+					kind = "product";
+				} else {
+					y2error("Unknown resolvable kind");
+				}
+				map->add(YCPString("kind"), YCPString(kind));
+
+				return map;
 			}
 		};
 

--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -146,67 +146,67 @@ namespace ZyppRecipients {
     ///////////////////////////////////////////////////////////////////
     struct InstallResolvableReportSA : public Recipient, public zypp::callback::ReceiveReport<zypp::target::rpm::InstallResolvableReportSA>
     {
-			InstallResolvableReportSA( RecipientCtl & construct_r ) : Recipient( construct_r ) {}
+	InstallResolvableReportSA( RecipientCtl & construct_r ) : Recipient( construct_r ) {}
 
-			virtual void start(zypp::Resolvable::constPtr resolvable, const UserData &userdata = UserData())
-      {
-		    CB callback( ycpcb( YCPCallbacks::CB_StartInstallResolvableSA ) );
+        virtual void start(zypp::Resolvable::constPtr resolvable, const UserData &userdata = UserData())
+        {
+	    CB callback( ycpcb( YCPCallbacks::CB_StartInstallResolvableSA ) );
 
-				if (callback._set) {
-					callback.addMap(resolvable2map(resolvable));
-					callback.evaluate();
-				}
-			}
+	    if (callback._set) {
+		callback.addMap(resolvable2map(resolvable));
+		callback.evaluate();
+	    }
+	}
 
-      virtual void progress(int value, zypp::Resolvable::constPtr resolvable, const UserData &userdata = UserData())
-      {
-		    CB callback( ycpcb( YCPCallbacks::CB_ProgressInstallResolvableSA ) );
+	virtual void progress(int value, zypp::Resolvable::constPtr resolvable, const UserData &userdata = UserData())
+	{
+	    CB callback( ycpcb( YCPCallbacks::CB_ProgressInstallResolvableSA ) );
 
-				if (callback._set) {
-					callback.addMap(resolvable2map(resolvable));
-					callback.addInt(value);
-					callback.evaluate();
-				}
-			}
+	    if (callback._set) {
+		callback.addMap(resolvable2map(resolvable));
+		callback.addInt(value);
+		callback.evaluate();
+		}
+	}
 
-      virtual void finish(zypp::Resolvable::constPtr resolvable, Error error, const UserData &userdata = UserData())
-			{
-		    CB callback( ycpcb( YCPCallbacks::CB_FinishInstallResolvableSA ) );
+	virtual void finish(zypp::Resolvable::constPtr resolvable, Error error, const UserData &userdata = UserData())
+	{
+	    CB callback( ycpcb( YCPCallbacks::CB_FinishInstallResolvableSA ) );
 
-				if (callback._set) {
-					callback.addMap(resolvable2map(resolvable));
-					callback.evaluate();
-				}
-			}
+	    if (callback._set) {
+		callback.addMap(resolvable2map(resolvable));
+		callback.evaluate();
+	    }
+	}
 
-			private:
+    private:
 
-			YCPMap resolvable2map(zypp::Resolvable::constPtr resolvable) {
-				YCPMap map;
-				map->add(YCPString("name"), YCPString(resolvable->name()));
-				map->add(YCPString("version"), YCPString(resolvable->edition().asString()));
-				map->add(YCPString("arch"), YCPString(resolvable->arch().asString()));
-				map->add(YCPString("repo_alias"), YCPString(resolvable->repoInfo().alias()));
+	YCPMap resolvable2map(zypp::Resolvable::constPtr resolvable) {
+	    YCPMap map;
+	    map->add(YCPString("name"), YCPString(resolvable->name()));
+	    map->add(YCPString("version"), YCPString(resolvable->edition().asString()));
+	    map->add(YCPString("arch"), YCPString(resolvable->arch().asString()));
+	    map->add(YCPString("repo_alias"), YCPString(resolvable->repoInfo().alias()));
 
-				string kind;
-				if (resolvable->isKind<zypp::Package>()) {
-					kind = "package";
-				} else if (resolvable->isKind<zypp::Patch>()) {
-					kind = "patch";
-				} else if (resolvable->isKind<zypp::Pattern>()) {
-					kind = "pattern";
-				} else if (resolvable->isKind<zypp::SrcPackage>()) {
-					kind = "srcpackage";
-				} else if (resolvable->isKind<zypp::Product>()) {
-					kind = "product";
-				} else {
-					y2error("Unknown resolvable kind");
-				}
-				map->add(YCPString("kind"), YCPString(kind));
+	    string kind;
+	    if (resolvable->isKind<zypp::Package>()) {
+		kind = "package";
+	    } else if (resolvable->isKind<zypp::Patch>()) {
+		kind = "patch";
+	    } else if (resolvable->isKind<zypp::Pattern>()) {
+		kind = "pattern";
+	    } else if (resolvable->isKind<zypp::SrcPackage>()) {
+		kind = "srcpackage";
+	    } else if (resolvable->isKind<zypp::Product>()) {
+		kind = "product";
+	    } else {
+		y2error("Unknown resolvable kind");
+	    }
+	    map->add(YCPString("kind"), YCPString(kind));
 
-				return map;
-			}
-		};
+	    return map;
+	}
+    };
 
     ///////////////////////////////////////////////////////////////////
     // InstallPkgCallback
@@ -1493,7 +1493,7 @@ class PkgFunctions::CallbackHandler::ZyppReceive : public ZyppRecipients::Recipi
     ZyppRecipients::RemovePkgReceive  _removePkgReceive;
     ZyppRecipients::DownloadResolvableReceive _providePkgReceive;
     ZyppRecipients::FileConflictReceive _fileConflictReceive;
-		ZyppRecipients::InstallResolvableReportSA _installResolvableReportSA;
+    ZyppRecipients::InstallResolvableReportSA _installResolvableReportSA;
 
     // media callback
     ZyppRecipients::MediaChangeReceive   _mediaChangeReceive;
@@ -1526,7 +1526,7 @@ class PkgFunctions::CallbackHandler::ZyppReceive : public ZyppRecipients::Recipi
       , _removePkgReceive( *this )
       , _providePkgReceive( *this, pkg )
       , _fileConflictReceive( *this )
-			, _installResolvableReportSA( *this )
+      , _installResolvableReportSA( *this )
       , _mediaChangeReceive( *this )
       , _downloadProgressReceive( *this )
       , _scriptExecReceive( *this )

--- a/src/Callbacks_Register.cc
+++ b/src/Callbacks_Register.cc
@@ -66,12 +66,31 @@ YCPValue PkgFunctions::CallbackResolvableReport( const YCPValue& args ) {
   return SET_YCP_CB( CB_ResolvableReport, args );
 }
 
+/**
+ * @builtin CallbackStartInstallResolvableSA
+ * @short Register callback for: Resolvable installation start
+ * @param funref cb Callback with prototype <code>void(map<string,any> resolvable)</code>. The map has string values for these string keys: kind, name, version, arch, repo_alias.
+ * @return void
+ */
 YCPValue PkgFunctions::CallbackStartInstallResolvableSA( const YCPValue& args ) {
   return SET_YCP_CB( CB_StartInstallResolvableSA, args );
 }
+/**
+ * @builtin CallbackProgressInstallResolvableSA
+ * @short Register callback for: Resolvable installation progress
+ * @param funref cb Callback with prototype <code>void(map<string,any> resolvable, integer value)</code>. The map has string values for these string keys: kind, name, version, arch, repo_alias.
+ * @return void
+ */
+
 YCPValue PkgFunctions::CallbackProgressInstallResolvableSA( const YCPValue& args ) {
   return SET_YCP_CB( CB_ProgressInstallResolvableSA, args );
 }
+/**
+ * @builtin CallbackFinishInstallResolvableSA
+ * @short Register callback for: Resolvable installation finish
+ * @param funref cb Callback with prototype <code>void(map<string,any> resolvable)</code>. The map has string values for these string keys: kind, name, version, arch, repo_alias.
+ * @return void
+ */
 YCPValue PkgFunctions::CallbackFinishInstallResolvableSA( const YCPValue& args ) {
   return SET_YCP_CB( CB_FinishInstallResolvableSA, args );
 }

--- a/src/Callbacks_Register.cc
+++ b/src/Callbacks_Register.cc
@@ -66,6 +66,17 @@ YCPValue PkgFunctions::CallbackResolvableReport( const YCPValue& args ) {
   return SET_YCP_CB( CB_ResolvableReport, args );
 }
 
+YCPValue PkgFunctions::CallbackStartInstallResolvableSA( const YCPValue& args ) {
+  return SET_YCP_CB( CB_StartInstallResolvableSA, args );
+}
+YCPValue PkgFunctions::CallbackProgressInstallResolvableSA( const YCPValue& args ) {
+  return SET_YCP_CB( CB_ProgressInstallResolvableSA, args );
+}
+YCPValue PkgFunctions::CallbackFinishInstallResolvableSA( const YCPValue& args ) {
+  return SET_YCP_CB( CB_FinishInstallResolvableSA, args );
+}
+
+
 /**
  * @builtin CallbackImportGpgKey
  * @short Register callback function

--- a/src/PkgFunctions.h
+++ b/src/PkgFunctions.h
@@ -321,6 +321,13 @@ class PkgFunctions
 	/* TYPEINFO: void(string(integer,string)) */
 	YCPValue CallbackDonePackage (const YCPValue& /*nil*/ args);
 
+	/* TYPEINFO: void(void(map<string,any>)) */
+	YCPValue CallbackStartInstallResolvableSA( const YCPValue& args );
+	/* TYPEINFO: void(void(map<string,any>,integer)) */
+	YCPValue CallbackProgressInstallResolvableSA( const YCPValue& args );
+	/* TYPEINFO: void(void(map<string,any>)) */
+	YCPValue CallbackFinishInstallResolvableSA( const YCPValue& args );
+
 	/* TYPEINFO: void(void(string,integer)) */
 	YCPValue CallbackStartDeltaDownload( const YCPValue& /*nil*/ args);
 	/* TYPEINFO: void(boolean(integer)) */


### PR DESCRIPTION
## Problem

- Implement the new libzypp callbacks
- For an overview see the corresponding Agama PR, https://github.com/agama-project/agama/pull/2522
- https://bugzilla.suse.com/show_bug.cgi?id=1244319

## Solution

- Initial implementation with subset of callbacks and passing just minimal data to YaST

## TODO

- [x] Fix indentation (VSCode displays it correctly...)
- [x] Add changes :smiley:

